### PR TITLE
Add no-op and custom remote persisters, and their CLI interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "futures",
+ "indoc",
  "insta",
  "moka",
  "ntest",

--- a/crates/abq_cli/src/instance/remote_persistence.rs
+++ b/crates/abq_cli/src/instance/remote_persistence.rs
@@ -1,0 +1,139 @@
+use std::{fmt::Display, str::FromStr};
+
+use abq_queue::persistence::remote::{
+    CustomPersister, NoopPersister, RemotePersister, S3Client, S3Persister,
+};
+
+use crate::args::Cli;
+
+pub const ENV_REMOTE_PERSISTENCE_STRATEGY: &str = "ABQ_REMOTE_PERSISTENCE_STRATEGY";
+pub const ENV_REMOTE_PERSISTENCE_COMMAND: &str = "ABQ_REMOTE_PERSISTENCE_COMMAND";
+pub const ENV_REMOTE_PERSISTENCE_S3_BUCKET: &str = "ABQ_REMOTE_PERSISTENCE_S3_BUCKET";
+pub const ENV_REMOTE_PERSISTENCE_S3_KEY_PREFIX: &str = "ABQ_REMOTE_PERSISTENCE_S3_KEY_PREFIX";
+
+#[derive(Clone)]
+pub enum RemotePersistenceStrategy {
+    S3,
+    Custom,
+}
+
+impl Display for RemotePersistenceStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RemotePersistenceStrategy::S3 => write!(f, "s3"),
+            RemotePersistenceStrategy::Custom => write!(f, "custom"),
+        }
+    }
+}
+
+impl FromStr for RemotePersistenceStrategy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "s3" => Ok(RemotePersistenceStrategy::S3),
+            "custom" => Ok(RemotePersistenceStrategy::Custom),
+            _ => Err(format!("unknown remote persistence strategy: {}", s)),
+        }
+    }
+}
+
+pub struct RemotePersistenceConfig {
+    strategy: Option<RemotePersistenceStrategy>,
+    remote_persistence_command: Option<String>,
+    remote_persistence_s3_bucket: Option<String>,
+    remote_persistence_s3_key_prefix: Option<String>,
+}
+
+pub type RemotePersisterResult = Result<RemotePersister, clap::Error>;
+
+impl RemotePersistenceConfig {
+    pub fn new(
+        strategy: Option<RemotePersistenceStrategy>,
+        remote_persistence_command: Option<String>,
+        remote_persistence_s3_bucket: Option<String>,
+        remote_persistence_s3_key_prefix: Option<String>,
+    ) -> Self {
+        Self {
+            strategy,
+            remote_persistence_command,
+            remote_persistence_s3_bucket,
+            remote_persistence_s3_key_prefix,
+        }
+    }
+
+    pub async fn resolve(self) -> RemotePersisterResult {
+        let Self {
+            strategy,
+            remote_persistence_command,
+            remote_persistence_s3_bucket,
+            remote_persistence_s3_key_prefix,
+        } = self;
+
+        let strategy = match strategy {
+            Some(strategy) => strategy,
+            None => return Ok(RemotePersister::new(NoopPersister::new())),
+        };
+
+        use RemotePersistenceStrategy::*;
+        match strategy {
+            S3 => {
+                build_s3_strategy(
+                    remote_persistence_s3_bucket,
+                    remote_persistence_s3_key_prefix,
+                )
+                .await
+            }
+            Custom => build_custom_strategy(remote_persistence_command),
+        }
+    }
+}
+
+fn missing_arg_for(arg: &str, strategy: RemotePersistenceStrategy) -> clap::Error {
+    use clap::{error::ErrorKind, CommandFactory};
+    let mut cmd = Cli::command();
+    cmd.error(
+        ErrorKind::MissingRequiredArgument,
+        format!(r#""{arg}" must be specified for remote persistence strategy "{strategy}""#),
+    )
+}
+
+async fn build_s3_strategy(
+    remote_persistence_s3_bucket: Option<String>,
+    remote_persistence_s3_key_prefix: Option<String>,
+) -> RemotePersisterResult {
+    let bucket = remote_persistence_s3_bucket.ok_or_else(|| {
+        missing_arg_for(
+            ENV_REMOTE_PERSISTENCE_S3_BUCKET,
+            RemotePersistenceStrategy::S3,
+        )
+    })?;
+    let key_prefix = remote_persistence_s3_key_prefix.ok_or_else(|| {
+        missing_arg_for(
+            ENV_REMOTE_PERSISTENCE_S3_KEY_PREFIX,
+            RemotePersistenceStrategy::S3,
+        )
+    })?;
+
+    let client = S3Client::new_from_env().await;
+
+    let persister = S3Persister::new(client, bucket, key_prefix);
+
+    Ok(RemotePersister::new(persister))
+}
+
+fn build_custom_strategy(remote_persistence_command: Option<String>) -> RemotePersisterResult {
+    let command = remote_persistence_command.ok_or_else(|| {
+        missing_arg_for(
+            ENV_REMOTE_PERSISTENCE_COMMAND,
+            RemotePersistenceStrategy::Custom,
+        )
+    })?;
+
+    let mut args: Vec<_> = command.split(',').map(ToOwned::to_owned).collect();
+    let command = args.remove(0);
+
+    let persister = CustomPersister::new(command, args);
+
+    Ok(RemotePersister::new(persister))
+}

--- a/crates/abq_queue/Cargo.toml
+++ b/crates/abq_queue/Cargo.toml
@@ -41,6 +41,7 @@ abq_with_protocol_version = { path = "../abq_test_support/with_protocol_version"
 abq_run_n_times = { path = "../abq_test_support/run_n_times" }
 abq_native_runner_simulation = { path = "../abq_test_support/native_runner_simulator" }
 
+indoc.workspace = true
 insta.workspace = true
 ntest.workspace = true
 tempfile.workspace = true

--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -14,6 +14,9 @@ mod s3;
 #[cfg(feature = "s3")]
 pub use s3::{S3Client, S3Persister};
 
+mod noop;
+pub use noop::NoopPersister;
+
 pub enum PersistenceKind {
     Manifest,
     Results,

--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -17,6 +17,9 @@ pub use s3::{S3Client, S3Persister};
 mod noop;
 pub use noop::NoopPersister;
 
+mod custom;
+pub use custom::CustomPersister;
+
 pub enum PersistenceKind {
     Manifest,
     Results,

--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -43,4 +43,39 @@ pub trait RemotePersistence {
         run_id: RunId,
         into_local_path: &Path,
     ) -> OpaqueResult<()>;
+
+    fn boxed_clone(&self) -> Box<dyn RemotePersistence>;
+}
+
+#[repr(transparent)]
+pub struct RemotePersister(Box<dyn RemotePersistence>);
+
+impl RemotePersister {
+    pub fn new(persister: impl RemotePersistence + 'static) -> RemotePersister {
+        RemotePersister(Box::new(persister))
+    }
+
+    pub async fn store(
+        &self,
+        kind: PersistenceKind,
+        run_id: RunId,
+        from_local_path: &Path,
+    ) -> OpaqueResult<()> {
+        self.0.store(kind, run_id, from_local_path).await
+    }
+
+    pub async fn load(
+        &self,
+        kind: PersistenceKind,
+        run_id: RunId,
+        into_local_path: &Path,
+    ) -> OpaqueResult<()> {
+        self.0.load(kind, run_id, into_local_path).await
+    }
+}
+
+impl Clone for RemotePersister {
+    fn clone(&self) -> Self {
+        Self(self.0.boxed_clone())
+    }
 }

--- a/crates/abq_queue/src/persistence/remote/custom.rs
+++ b/crates/abq_queue/src/persistence/remote/custom.rs
@@ -23,6 +23,7 @@ use super::{PersistenceKind, RemotePersistence};
 ///
 /// If the process exits with a non-zero exit code, the error message will be the contents of the
 /// process's standard error.
+#[derive(Clone)]
 pub struct CustomPersister {
     command: String,
     head_args: Vec<String>,
@@ -95,6 +96,10 @@ impl RemotePersistence for CustomPersister {
 
     async fn store(&self, kind: PersistenceKind, run_id: RunId, path: &Path) -> OpaqueResult<()> {
         self.call(Action::Store, kind, run_id, path).await
+    }
+
+    fn boxed_clone(&self) -> Box<dyn RemotePersistence> {
+        Box::new(self.clone())
     }
 }
 

--- a/crates/abq_queue/src/persistence/remote/custom.rs
+++ b/crates/abq_queue/src/persistence/remote/custom.rs
@@ -1,0 +1,208 @@
+use std::path::Path;
+
+use abq_utils::{
+    error::{OpaqueResult, ResultLocation},
+    here,
+    net_protocol::workers::RunId,
+};
+use async_trait::async_trait;
+
+use super::{PersistenceKind, RemotePersistence};
+
+/// A custom [remote file persistor][RemotePersistence], whose implementation is defined by an
+/// external process.
+///
+/// The process the custom persistor is [created][CustomPersister::new] with must be an executable
+/// in the PATH, and is called in the following form:
+///
+/// ```bash
+/// <command> <..args> <action=load|store> <kind=manifest|results> <run_id> <path_to_load_or_store>
+/// ```
+///
+/// The process must exit with a zero exit code on success, and a non-zero exit code on failure.
+///
+/// If the process exits with a non-zero exit code, the error message will be the contents of the
+/// process's standard error.
+pub struct CustomPersister {
+    command: String,
+    head_args: Vec<String>,
+}
+
+enum Action {
+    Load,
+    Store,
+}
+
+impl CustomPersister {
+    /// Creates a new custom persister from the given command and head arguments.
+    ///
+    /// The command must be an executable in the PATH, and confirm to the described [calling
+    /// convention][CustomPersister].
+    pub fn new(command: impl Into<String>, head_args: impl Into<Vec<String>>) -> Self {
+        Self {
+            command: command.into(),
+            head_args: head_args.into(),
+        }
+    }
+
+    async fn call(
+        &self,
+        action: Action,
+        kind: PersistenceKind,
+        run_id: RunId,
+        path: &Path,
+    ) -> OpaqueResult<()> {
+        let action = match action {
+            Action::Load => "load",
+            Action::Store => "store",
+        };
+        let kind = match kind {
+            PersistenceKind::Manifest => "manifest",
+            PersistenceKind::Results => "results",
+        };
+
+        let std::process::Output {
+            status,
+            stdout: _,
+            stderr,
+        } = tokio::process::Command::new(&self.command)
+            .args(&self.head_args)
+            .arg(action)
+            .arg(kind)
+            .arg(run_id.to_string())
+            .arg(path)
+            .output()
+            .await
+            .located(here!())?;
+
+        if !status.success() {
+            return Err(format!(
+                "custom persister exited with non-zero exit code: {}",
+                String::from_utf8_lossy(&stderr)
+            ))
+            .located(here!());
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl RemotePersistence for CustomPersister {
+    async fn load(&self, kind: PersistenceKind, run_id: RunId, path: &Path) -> OpaqueResult<()> {
+        self.call(Action::Load, kind, run_id, path).await
+    }
+
+    async fn store(&self, kind: PersistenceKind, run_id: RunId, path: &Path) -> OpaqueResult<()> {
+        self.call(Action::Store, kind, run_id, path).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{io::Write, path::Path};
+
+    use abq_utils::net_protocol::workers::RunId;
+    use indoc::indoc;
+    use tempfile::NamedTempFile;
+
+    use crate::persistence::remote::RemotePersistence;
+
+    fn write_js(content: &str) -> NamedTempFile {
+        let mut fi = NamedTempFile::new().unwrap();
+        fi.write_all(content.as_bytes()).unwrap();
+        fi
+    }
+
+    #[tokio::test]
+    async fn load_okay() {
+        let fi = write_js(indoc!(
+            r#"
+            if (process.argv[2] !== "load") process.exit(1);
+            if (process.argv[3] !== "manifest") process.exit(1);
+            if (process.argv[4] !== "run-id") process.exit(1);
+            if (process.argv[5] !== "/tmp/foo") process.exit(1);
+            "#,
+        ));
+
+        let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
+
+        persister
+            .load(
+                super::PersistenceKind::Manifest,
+                RunId("run-id".to_string()),
+                Path::new("/tmp/foo"),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn load_error() {
+        let fi = write_js(indoc!(
+            r#"
+            console.error("I have failed");
+            process.exit(1);
+            "#,
+        ));
+
+        let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
+
+        let err = persister
+            .load(
+                super::PersistenceKind::Manifest,
+                RunId("run-id".to_string()),
+                Path::new("/tmp/foo"),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("I have failed"));
+    }
+
+    #[tokio::test]
+    async fn store_okay() {
+        let fi = write_js(indoc!(
+            r#"
+            if (process.argv[2] !== "store") process.exit(1);
+            if (process.argv[3] !== "manifest") process.exit(1);
+            if (process.argv[4] !== "run-id") process.exit(1);
+            if (process.argv[5] !== "/tmp/foo") process.exit(1);
+            "#,
+        ));
+
+        let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
+
+        persister
+            .store(
+                super::PersistenceKind::Manifest,
+                RunId("run-id".to_string()),
+                Path::new("/tmp/foo"),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn store_error() {
+        let fi = write_js(indoc!(
+            r#"
+            console.error("I have failed");
+            process.exit(1);
+            "#,
+        ));
+
+        let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
+
+        let err = persister
+            .store(
+                super::PersistenceKind::Manifest,
+                RunId("run-id".to_string()),
+                Path::new("/tmp/foo"),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("I have failed"));
+    }
+}

--- a/crates/abq_queue/src/persistence/remote/noop.rs
+++ b/crates/abq_queue/src/persistence/remote/noop.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 
 use super::{PersistenceKind, RemotePersistence};
 
+#[derive(Clone, Default)]
 pub struct NoopPersister;
 
 impl NoopPersister {
@@ -35,5 +36,9 @@ impl RemotePersistence for NoopPersister {
         _into_local_path: &Path,
     ) -> OpaqueResult<()> {
         Err("NoopPersister does not support loading.".located(here!()))
+    }
+
+    fn boxed_clone(&self) -> Box<dyn RemotePersistence> {
+        Box::new(self.clone())
     }
 }

--- a/crates/abq_queue/src/persistence/remote/noop.rs
+++ b/crates/abq_queue/src/persistence/remote/noop.rs
@@ -1,0 +1,39 @@
+use std::path::Path;
+
+use abq_utils::{
+    error::{ErrorLocation, OpaqueResult},
+    here,
+    net_protocol::workers::RunId,
+};
+use async_trait::async_trait;
+
+use super::{PersistenceKind, RemotePersistence};
+
+pub struct NoopPersister;
+
+impl NoopPersister {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl RemotePersistence for NoopPersister {
+    async fn store(
+        &self,
+        _kind: PersistenceKind,
+        _run_id: RunId,
+        _from_local_path: &Path,
+    ) -> OpaqueResult<()> {
+        Ok(())
+    }
+
+    async fn load(
+        &self,
+        _kind: PersistenceKind,
+        _run_id: RunId,
+        _into_local_path: &Path,
+    ) -> OpaqueResult<()> {
+        Err("NoopPersister does not support loading.".located(here!()))
+    }
+}


### PR DESCRIPTION
The CLI now supports two modes for remote persistence - either via a
custom executable, or via configuring S3 for storage. If neither is
specified, remote persistence will not be used.

See individual commits for details. In a follow-up, these paths will begin to be exercised. For now, this is stubbed out to get a feel for the interface.