### PR TITLE
Log total workers seen when manifest completes.

### DIFF
--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -921,8 +921,6 @@ impl AllRuns {
             }
         };
 
-        tracing::info!(?run_id, "marking end of manifest");
-
         let mut seen_workers = WorkerSet::default();
 
         for (worker, opt_completed) in active_worker_timings {
@@ -930,6 +928,8 @@ impl AllRuns {
             let is_active = opt_completed.is_none();
             seen_workers.insert_by_tag(worker, is_active);
         }
+
+        tracing::info!(?run_id, worker_count=?seen_workers.worker_count(), "marking end of manifest");
 
         // Build the plan to persist the manifest.
         let view = queue.into_manifest_view();

--- a/crates/abq_queue/src/worker_tracking.rs
+++ b/crates/abq_queue/src/worker_tracking.rs
@@ -60,6 +60,22 @@ impl<T> WorkerSet<T> {
     pub fn iter(&self) -> impl Iterator<Item = &(Entity, T)> {
         self.0.iter()
     }
+
+    /// Get the number of unique workers.
+    ///
+    /// Multiple runners for the same worker are only counted once.
+    pub fn worker_count(&self) -> usize {
+        let mut workers = self
+            .iter()
+            .filter_map(|(k, _)| match k.tag {
+                Tag::Runner(wr) => Some(wr.worker()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        workers.sort_unstable();
+        workers.dedup();
+        workers.len()
+    }
 }
 
 impl<V> IntoIterator for WorkerSet<V> {


### PR DESCRIPTION
Provides some additional observability from the queue by logging the number of workers seen on a given run.