### PR TITLE
Integrate dumping manifests to remote as part of manifest persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,8 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "pest",
+ "pest_derive",
  "serde",
  "similar",
  "yaml-rust",
@@ -1924,6 +1926,50 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pest"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.10",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project"
@@ -2875,6 +2921,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ derive_more = "0.99.17"
 
 # --- Development ---
 
-insta = { version = "1.29.0", features = ["json"] }
+insta = { version = "1.29.0", features = ["json", "redactions"] }
 paste = "1.0.12"
 
 fs4 = "0.6.3"

--- a/crates/abq_cli/src/instance.rs
+++ b/crates/abq_cli/src/instance.rs
@@ -1,4 +1,5 @@
 use abq_queue::persistence;
+use abq_queue::persistence::remote::NoopPersister;
 use abq_queue::queue::{Abq, QueueConfig};
 use abq_utils::auth::{AdminToken, ServerAuthStrategy, UserToken};
 use abq_utils::exit::ExitCode;
@@ -46,8 +47,10 @@ pub async fn start_abq_forever(
     let remote_persistence = remote_persistence_config.resolve().await?;
 
     let manifests_path = tempfile::tempdir().expect("unable to create a temporary file");
-    let persist_manifest =
-        persistence::manifest::FilesystemPersistor::new_shared(manifests_path.path());
+    let persist_manifest = persistence::manifest::FilesystemPersistor::new_shared(
+        manifests_path.path(),
+        NoopPersister,
+    );
 
     let results_path = tempfile::tempdir().expect("unable to create a temporary file");
     let persist_results = persistence::results::FilesystemPersistor::new_shared(
@@ -196,8 +199,10 @@ impl AbqInstance {
         };
 
         let manifests_path = tempfile::tempdir().expect("unable to create a temporary file");
-        let persist_manifest =
-            persistence::manifest::FilesystemPersistor::new_shared(manifests_path.path());
+        let persist_manifest = persistence::manifest::FilesystemPersistor::new_shared(
+            manifests_path.path(),
+            NoopPersister,
+        );
 
         let results_path = tempfile::tempdir().expect("unable to create a temporary file");
         let persist_results =

--- a/crates/abq_cli/src/instance.rs
+++ b/crates/abq_cli/src/instance.rs
@@ -43,13 +43,12 @@ pub async fn start_abq_forever(
     // Public IP defaults to the binding IP.
     let public_ip = public_ip.unwrap_or(bind_ip);
 
-    #[allow(unused)] // for now
     let remote_persistence = remote_persistence_config.resolve().await?;
 
     let manifests_path = tempfile::tempdir().expect("unable to create a temporary file");
     let persist_manifest = persistence::manifest::FilesystemPersistor::new_shared(
         manifests_path.path(),
-        NoopPersister,
+        remote_persistence,
     );
 
     let results_path = tempfile::tempdir().expect("unable to create a temporary file");

--- a/crates/abq_queue/src/persistence/manifest.rs
+++ b/crates/abq_queue/src/persistence/manifest.rs
@@ -19,7 +19,7 @@ use abq_utils::{
 use async_trait::async_trait;
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ManifestView {
     items: Vec<WorkerTest>,
     assigned_entities: Vec<Tag>,

--- a/crates/abq_queue/src/persistence/remote/custom.rs
+++ b/crates/abq_queue/src/persistence/remote/custom.rs
@@ -50,7 +50,7 @@ impl CustomPersister {
         &self,
         action: Action,
         kind: PersistenceKind,
-        run_id: RunId,
+        run_id: &RunId,
         path: &Path,
     ) -> OpaqueResult<()> {
         let action = match action {
@@ -90,15 +90,15 @@ impl CustomPersister {
 
 #[async_trait]
 impl RemotePersistence for CustomPersister {
-    async fn load(&self, kind: PersistenceKind, run_id: RunId, path: &Path) -> OpaqueResult<()> {
+    async fn load(&self, kind: PersistenceKind, run_id: &RunId, path: &Path) -> OpaqueResult<()> {
         self.call(Action::Load, kind, run_id, path).await
     }
 
-    async fn store(&self, kind: PersistenceKind, run_id: RunId, path: &Path) -> OpaqueResult<()> {
+    async fn store(&self, kind: PersistenceKind, run_id: &RunId, path: &Path) -> OpaqueResult<()> {
         self.call(Action::Store, kind, run_id, path).await
     }
 
-    fn boxed_clone(&self) -> Box<dyn RemotePersistence> {
+    fn boxed_clone(&self) -> Box<dyn RemotePersistence + Send + Sync> {
         Box::new(self.clone())
     }
 }
@@ -135,7 +135,7 @@ mod test {
         persister
             .load(
                 super::PersistenceKind::Manifest,
-                RunId("run-id".to_string()),
+                &RunId("run-id".to_string()),
                 Path::new("/tmp/foo"),
             )
             .await
@@ -156,7 +156,7 @@ mod test {
         let err = persister
             .load(
                 super::PersistenceKind::Manifest,
-                RunId("run-id".to_string()),
+                &RunId("run-id".to_string()),
                 Path::new("/tmp/foo"),
             )
             .await
@@ -181,7 +181,7 @@ mod test {
         persister
             .store(
                 super::PersistenceKind::Manifest,
-                RunId("run-id".to_string()),
+                &RunId("run-id".to_string()),
                 Path::new("/tmp/foo"),
             )
             .await
@@ -202,7 +202,7 @@ mod test {
         let err = persister
             .store(
                 super::PersistenceKind::Manifest,
-                RunId("run-id".to_string()),
+                &RunId("run-id".to_string()),
                 Path::new("/tmp/foo"),
             )
             .await

--- a/crates/abq_queue/src/persistence/remote/fake.rs
+++ b/crates/abq_queue/src/persistence/remote/fake.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+
+use abq_utils::{error::OpaqueResult, net_protocol::workers::RunId};
+use async_trait::async_trait;
+
+use super::{PersistenceKind, RemotePersistence};
+
+#[derive(Clone)]
+pub struct FakePersister<OnStore, OnLoad> {
+    on_store: OnStore,
+    on_load: OnLoad,
+}
+
+impl<OnStore, OnLoad> FakePersister<OnStore, OnLoad>
+where
+    OnStore: Fn(PersistenceKind, &RunId, &Path) -> OpaqueResult<()> + Send + Sync,
+    OnLoad: Fn(PersistenceKind, &RunId, &Path) -> OpaqueResult<()> + Send + Sync,
+{
+    pub fn new(on_store: OnStore, on_load: OnLoad) -> Self {
+        Self { on_store, on_load }
+    }
+}
+
+#[async_trait]
+impl<OnStore, OnLoad> RemotePersistence for FakePersister<OnStore, OnLoad>
+where
+    OnStore: Fn(PersistenceKind, &RunId, &Path) -> OpaqueResult<()> + Send + Sync + Clone + 'static,
+    OnLoad: Fn(PersistenceKind, &RunId, &Path) -> OpaqueResult<()> + Send + Sync + Clone + 'static,
+{
+    async fn store(
+        &self,
+        kind: PersistenceKind,
+        run_id: &RunId,
+        from_local_path: &Path,
+    ) -> OpaqueResult<()> {
+        (self.on_store)(kind, run_id, from_local_path)
+    }
+
+    async fn load(
+        &self,
+        kind: PersistenceKind,
+        run_id: &RunId,
+        into_local_path: &Path,
+    ) -> OpaqueResult<()> {
+        (self.on_load)(kind, run_id, into_local_path)
+    }
+
+    fn boxed_clone(&self) -> Box<dyn RemotePersistence + Send + Sync> {
+        Box::new(self.clone())
+    }
+}

--- a/crates/abq_queue/src/persistence/remote/noop.rs
+++ b/crates/abq_queue/src/persistence/remote/noop.rs
@@ -23,7 +23,7 @@ impl RemotePersistence for NoopPersister {
     async fn store(
         &self,
         _kind: PersistenceKind,
-        _run_id: RunId,
+        _run_id: &RunId,
         _from_local_path: &Path,
     ) -> OpaqueResult<()> {
         Ok(())
@@ -32,13 +32,13 @@ impl RemotePersistence for NoopPersister {
     async fn load(
         &self,
         _kind: PersistenceKind,
-        _run_id: RunId,
+        _run_id: &RunId,
         _into_local_path: &Path,
     ) -> OpaqueResult<()> {
         Err("NoopPersister does not support loading.".located(here!()))
     }
 
-    fn boxed_clone(&self) -> Box<dyn RemotePersistence> {
+    fn boxed_clone(&self) -> Box<dyn RemotePersistence + Send + Sync> {
         Box::new(self.clone())
     }
 }

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -82,8 +82,10 @@ enum Servers {
 impl Default for Servers {
     fn default() -> Self {
         let manifests_path = tempfile::tempdir().unwrap();
-        let persist_manifest =
-            persistence::manifest::FilesystemPersistor::new_shared(manifests_path.path());
+        let persist_manifest = persistence::manifest::FilesystemPersistor::new_shared(
+            manifests_path.path(),
+            persistence::remote::NoopPersister,
+        );
 
         let results_path = tempfile::tempdir().unwrap();
         let persist_results =


### PR DESCRIPTION
Now, when a queue persists a manifest to local disk after the initial manifest has been handed out, it will also persist that manifest to a remote (if any).

Needs #4 first.