### PR TITLE
Cancel runs if no progress is made in the manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "moka",
  "ntest",
  "parking_lot",
+ "pin-project-lite",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tokio = { version = "1.26.0", features = [
 ] }
 tokio-rustls = "0.23.4"
 futures = "0.3.27"
+pin-project-lite = "0.2.9"
 
 parking_lot = "0.12.1"
 moka = { version = "0.10.0", features = ["future"] }

--- a/crates/abq_cli/src/instance.rs
+++ b/crates/abq_cli/src/instance.rs
@@ -1,6 +1,7 @@
 use abq_queue::persistence;
 use abq_queue::persistence::remote::NoopPersister;
 use abq_queue::queue::{Abq, QueueConfig};
+use abq_queue::{persistence, RunTimeoutStrategy};
 use abq_utils::auth::{AdminToken, ServerAuthStrategy, UserToken};
 use abq_utils::exit::ExitCode;
 use abq_utils::net_opt::ServerOptions;
@@ -57,6 +58,8 @@ pub async fn start_abq_forever(
         RESULTS_PERSISTENCE_LRU_CAPACITY,
     );
 
+    let run_timeout_strategy = RunTimeoutStrategy::RUN_BASED;
+
     let queue_config = QueueConfig {
         public_ip,
         bind_ip,
@@ -66,6 +69,7 @@ pub async fn start_abq_forever(
         server_options,
         persist_manifest,
         persist_results,
+        run_timeout_strategy,
     };
     let mut abq = Abq::start(queue_config).await;
 

--- a/crates/abq_cli/src/instance.rs
+++ b/crates/abq_cli/src/instance.rs
@@ -1,7 +1,7 @@
 use abq_queue::persistence;
 use abq_queue::persistence::remote::NoopPersister;
 use abq_queue::queue::{Abq, QueueConfig};
-use abq_queue::{persistence, RunTimeoutStrategy};
+use abq_queue::RunTimeoutStrategy;
 use abq_utils::auth::{AdminToken, ServerAuthStrategy, UserToken};
 use abq_utils::exit::ExitCode;
 use abq_utils::net_opt::ServerOptions;

--- a/crates/abq_queue/Cargo.toml
+++ b/crates/abq_queue/Cargo.toml
@@ -23,6 +23,7 @@ tracing.workspace = true
 tokio.workspace = true
 futures.workspace = true
 async-trait.workspace = true
+pin-project-lite.workspace = true
 
 anyhow.workspace = true
 

--- a/crates/abq_queue/src/job_queue.rs
+++ b/crates/abq_queue/src/job_queue.rs
@@ -120,6 +120,11 @@ impl JobQueue {
 
         persistence::manifest::ManifestView::new(queue, assigned_entities)
     }
+
+    /// Reads the current index at a given point in time. Not atomic.
+    pub fn read_index(&self) -> usize {
+        self.ptr.load(atomic::ORDERING)
+    }
 }
 
 #[cfg(test)]

--- a/crates/abq_queue/src/lib.rs
+++ b/crates/abq_queue/src/lib.rs
@@ -8,3 +8,5 @@ pub mod queue;
 mod timeout;
 mod worker_timings;
 mod worker_tracking;
+
+pub use timeout::{RunTimeoutStrategy, TimeoutReason};

--- a/crates/abq_queue/src/lib.rs
+++ b/crates/abq_queue/src/lib.rs
@@ -5,5 +5,6 @@ mod prelude;
 mod job_queue;
 pub mod persistence;
 pub mod queue;
+mod timeout;
 mod worker_timings;
 mod worker_tracking;

--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -3421,7 +3421,7 @@ mod test {
                 newly_observed_test_index: 1,
             } => {
                 assert_eq!(work_bundle.work.len(), 1);
-                assert!(work_bundle.eow);
+                assert!(!work_bundle.eow);
                 assert_eq!(work_status, PulledTestsStatus::MoreTestsRemaining);
                 assert_eq!(queues.get_run_status(&run_id), Some(RunStatus::Active));
             }

--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -424,7 +424,7 @@ impl AllRuns {
                     tracing::info!(
                         ?run_id,
                         ?entity,
-                        "worker reconnecting for out-of-process retry manifest afer initial run"
+                        "worker reconnecting for out-of-process retry manifest after initial run"
                     );
                     AssignedRunStatus::Run(AssignedRun::Retry)
                 } else {

--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -424,7 +424,7 @@ impl AllRuns {
                     tracing::info!(
                         ?run_id,
                         ?entity,
-                        "worker reconnecting for out-of-process retry manifest during active run"
+                        "worker reconnecting for out-of-process retry manifest afer initial run"
                     );
                     AssignedRunStatus::Run(AssignedRun::Retry)
                 } else {
@@ -563,6 +563,7 @@ impl AllRuns {
                         ?entity,
                         "assigning init metadata to out-of-process retry"
                     );
+                    seen_workers.write().insert_by_tag(entity, true);
                     // This worker was already involved in this run; assume it's connecting for an
                     // out-of-process retry.
                     InitMetadata::Metadata(init_metadata.clone())

--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -33,10 +33,8 @@ use abq_utils::server_shutdown::{ShutdownManager, ShutdownReceiver};
 use abq_utils::tls::ServerTlsStrategy;
 use abq_utils::vec_map::VecMap;
 use abq_utils::{atomic, illegal_state, log_assert};
-use abq_workers::negotiate::{
-    AssignedRun, AssignedRunStatus, GetAssignedRun, QueueNegotiator, QueueNegotiatorHandle,
-    QueueNegotiatorServerError,
-};
+use abq_workers::negotiate::{QueueNegotiator, QueueNegotiatorHandle, QueueNegotiatorServerError};
+use abq_workers::{AssignedRun, AssignedRunStatus, GetAssignedRun};
 
 use async_trait::async_trait;
 use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
@@ -2561,7 +2559,7 @@ mod test {
         tls::{ClientTlsStrategy, ServerTlsStrategy},
     };
     use abq_with_protocol_version::with_protocol_version;
-    use abq_workers::negotiate::{AssignedRun, AssignedRunStatus};
+    use abq_workers::{AssignedRun, AssignedRunStatus};
     use tracing_test::traced_test;
 
     fn test_queue() -> QueueServer {
@@ -3588,7 +3586,7 @@ mod retry_manifest {
         tls::{ClientTlsStrategy, ServerTlsStrategy},
     };
     use abq_with_protocol_version::with_protocol_version;
-    use abq_workers::negotiate::{AssignedRun, AssignedRunStatus};
+    use abq_workers::{AssignedRun, AssignedRunStatus};
     use ntest::timeout;
     use tokio::task::JoinHandle;
 

--- a/crates/abq_queue/src/timeout.rs
+++ b/crates/abq_queue/src/timeout.rs
@@ -1,0 +1,281 @@
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use abq_utils::net_protocol::{queue::CancelReason, workers::RunId};
+use futures::{stream::FuturesUnordered, StreamExt};
+use std::future::Future;
+use tokio::sync::RwLock;
+
+#[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
+pub struct RunTimeoutStrategy(RunTimeoutStrategyPriv);
+
+impl RunTimeoutStrategy {
+    /// Determine the timeout from the parameters of a test run.
+    pub const RUN_BASED: Self = RunTimeoutStrategy(RunTimeoutStrategyPriv::RunBased);
+
+    /// Constant timeout, for use in testing.
+    pub fn constant(f: fn(TimeoutReason) -> Duration) -> Self {
+        Self(RunTimeoutStrategyPriv::Constant(f))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RunTimeoutStrategyPriv {
+    RunBased,
+    Constant(fn(TimeoutReason) -> Duration),
+}
+
+impl Default for RunTimeoutStrategy {
+    fn default() -> Self {
+        Self::RUN_BASED
+    }
+}
+
+/// How long to wait before a manifest must make progress, or else its associated run is timed-out.
+const WAIT_FOR_MANIFEST_PROGRESS_DURATION: Duration = Duration::from_secs(60 * 60); // 1 hour
+
+impl RunTimeoutStrategy {
+    /// Determine a duration for how long to wait before a manifest must make progress, or
+    /// else its associated run is timed-out.
+    pub(crate) fn wait_for_manifest_progress_duration(&self) -> TimeoutSpec {
+        let reason = TimeoutReason::WaitForManifestProgress;
+        let duration = match self.0 {
+            RunTimeoutStrategyPriv::RunBased => WAIT_FOR_MANIFEST_PROGRESS_DURATION,
+            RunTimeoutStrategyPriv::Constant(timeout) => timeout(reason),
+        };
+        TimeoutSpec { duration, reason }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct TimeoutSpec {
+    duration: Duration,
+    reason: TimeoutReason,
+}
+
+impl TimeoutSpec {
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+}
+
+/// Records runs that should timeout after a certain amount of time.
+/// Fires [RunTimeoutManager::next_timeout] when a timeout is reached.
+#[derive(Clone)]
+pub(crate) struct RunTimeoutManager {
+    strategy: RunTimeoutStrategy,
+    timeouts: Arc<RwLock<FuturesUnordered<TimeoutCell>>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum TimeoutReason {
+    /// A test run was timed-out because no progress was made in popping tests off the manifest in
+    /// time.
+    WaitForManifestProgress,
+}
+
+impl From<TimeoutReason> for CancelReason {
+    fn from(reason: TimeoutReason) -> Self {
+        match reason {
+            TimeoutReason::WaitForManifestProgress => CancelReason::ManifestHadNoProgress,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct TimedOutRun {
+    pub run_id: RunId,
+    pub after: Duration,
+    pub reason: TimeoutReason,
+}
+
+struct TimeoutCell {
+    timeout: Pin<Box<dyn Future<Output = TimedOutRun> + Send + Sync + 'static>>,
+}
+
+impl Future for TimeoutCell {
+    type Output = TimedOutRun;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.timeout).poll(cx)
+    }
+}
+
+impl RunTimeoutManager {
+    const MAX_TIMEOUT_WAIT_TIME: Duration = Duration::from_micros(10);
+
+    pub fn new(strategy: RunTimeoutStrategy) -> Self {
+        Self {
+            strategy,
+            timeouts: Default::default(),
+        }
+    }
+
+    pub fn strategy(&self) -> RunTimeoutStrategy {
+        self.strategy
+    }
+
+    /// Inserts a new timeout for a given run ID.
+    /// Thread safe and takes only a read over a read/write lock; this makes insertions relatively
+    /// cheap across threads, while waiting for timeouts requires exclusive access.
+    pub async fn insert_run(&self, run_id: RunId, timeout_spec: TimeoutSpec) {
+        let TimeoutSpec { duration, reason } = timeout_spec;
+        let runs = self.timeouts.read().await;
+        let fut = Box::pin(async move {
+            tokio::time::sleep(duration).await;
+            TimedOutRun {
+                run_id,
+                after: duration,
+                reason,
+            }
+        });
+        let timeout_cell = TimeoutCell { timeout: fut };
+
+        // NB: We should attempt to minimize memory leaks by dropping timeout
+        // cells that are no longer active, or reusing their memory. The latter
+        // is preferable, but since timeout allocations should be far and few-between
+        // in a queue's lifetime, either is acceptable. The present implementation
+        // of `FuturesUnordered` provides the former:
+        //
+        //   https://docs.rs/futures-util/0.3.25/src/futures_util/stream/futures_unordered/mod.rs.html#79-102
+        runs.push(timeout_cell);
+    }
+
+    /// Yields the next timeout, once it fires. The procedure takes a write lock,
+    /// but will yield at regular intervals for [new runs][Self::insert_run].
+    /// If there are no timeouts, this call will not return, or will only return after a new
+    /// timeout is inserted.
+    pub async fn next_timeout(&self) -> TimedOutRun {
+        loop {
+            let mut runs = self.timeouts.write().await;
+            // TODO: consider using futures::select_biased, since the max-wait path
+            // is far more likely to fire.
+            tokio::select! {
+                _ = tokio::time::sleep(Self::MAX_TIMEOUT_WAIT_TIME) => {
+                    continue;
+                }
+                Some(timeout) = runs.next() => {
+                    return timeout;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashSet, time::Duration};
+
+    use abq_utils::net_protocol::workers::RunId;
+
+    use crate::timeout::{RunTimeoutStrategy, TimedOutRun, TimeoutReason, TimeoutSpec};
+
+    use super::RunTimeoutManager;
+
+    fn zero(_: TimeoutReason) -> Duration {
+        Duration::ZERO
+    }
+
+    #[tokio::test]
+    async fn fire_one_timeout() {
+        let manager = RunTimeoutManager::new(RunTimeoutStrategy::constant(zero));
+
+        let run_id = RunId::unique();
+
+        let spec = manager.strategy().wait_for_manifest_progress_duration();
+
+        manager.insert_run(run_id.clone(), spec).await;
+        assert_eq!(
+            manager.next_timeout().await,
+            TimedOutRun {
+                run_id,
+                after: Duration::ZERO,
+                reason: TimeoutReason::WaitForManifestProgress,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn fire_multiple_timeouts() {
+        let manager = RunTimeoutManager::new(RunTimeoutStrategy::constant(zero));
+
+        let run_id1 = RunId::unique();
+        let run_id2 = RunId::unique();
+        let run_id3 = RunId::unique();
+
+        let spec = TimeoutSpec {
+            duration: Duration::ZERO,
+            reason: TimeoutReason::WaitForManifestProgress,
+        };
+
+        manager.insert_run(run_id1.clone(), spec).await;
+        manager.insert_run(run_id2.clone(), spec).await;
+        manager.insert_run(run_id3.clone(), spec).await;
+
+        let mut timed_out = HashSet::new();
+        let mut afters = HashSet::new();
+
+        for _ in 0..3 {
+            let TimedOutRun {
+                run_id,
+                after,
+                reason: _,
+            } = manager.next_timeout().await;
+            timed_out.insert(run_id);
+            afters.insert(after);
+        }
+
+        assert_eq!(timed_out.len(), 3);
+        assert!(timed_out.contains(&run_id1));
+        assert!(timed_out.contains(&run_id2));
+        assert!(timed_out.contains(&run_id3));
+
+        assert_eq!(afters.len(), 1);
+        assert!(afters.contains(&Duration::ZERO));
+    }
+
+    #[tokio::test]
+    async fn yield_to_contest() {
+        let manager = RunTimeoutManager::new(RunTimeoutStrategy::default());
+
+        // Make sure long-lived timeouts allow contest - `old` timeout here should allow `young` to
+        // compete, and moreover `young` should always finish first.
+
+        let old_timeout = Duration::MAX;
+        let old_run_id = RunId::unique();
+
+        let old_spec = TimeoutSpec {
+            duration: old_timeout,
+            reason: TimeoutReason::WaitForManifestProgress,
+        };
+
+        let young_timeout = Duration::from_micros(10);
+        let young_run_id = RunId::unique();
+
+        let young_spec = TimeoutSpec {
+            duration: young_timeout,
+            reason: TimeoutReason::WaitForManifestProgress,
+        };
+
+        manager.insert_run(old_run_id, old_spec).await;
+
+        tokio::select! {
+            _insert_young = manager.insert_run(young_run_id.clone(), young_spec) => (),
+            _wait_for_old = manager.next_timeout() => unreachable!(),
+        };
+
+        assert_eq!(
+            manager.next_timeout().await,
+            TimedOutRun {
+                run_id: young_run_id,
+                after: young_timeout,
+                reason: TimeoutReason::WaitForManifestProgress,
+            }
+        )
+    }
+}

--- a/crates/abq_queue/src/timeout.rs
+++ b/crates/abq_queue/src/timeout.rs
@@ -110,6 +110,12 @@ impl Future for TimeoutCell {
     }
 }
 
+impl Default for RunTimeoutManager {
+    fn default() -> Self {
+        Self::new(RunTimeoutStrategy::default())
+    }
+}
+
 impl RunTimeoutManager {
     const MAX_TIMEOUT_WAIT_TIME: Duration = Duration::from_micros(10);
 

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -2383,6 +2383,7 @@ async fn cancellation_of_out_of_process_retry_does_not_cancel_run() {
 
 #[tokio::test]
 #[with_protocol_version]
+#[traced_test]
 async fn cancel_test_run_if_no_manifest_progress() {
     let manifest = ManifestMessage::new(Manifest::new(
         [echo_test(proto, "echo1".to_string())],
@@ -2427,4 +2428,9 @@ async fn cancel_test_run_if_no_manifest_progress() {
         )
         .test()
         .await;
+
+    assert_scoped_log(
+        "abq_queue::queue",
+        "run cancelled because manifest made no progress",
+    );
 }

--- a/crates/abq_utils/src/net_protocol.rs
+++ b/crates/abq_utils/src/net_protocol.rs
@@ -559,8 +559,8 @@ pub mod queue {
     pub enum CancelReason {
         /// The test run was cancelled on a worker
         User,
-        /// Timed out waiting for the last test result in a test run.
-        TimeoutOnTestResult,
+        /// Timed out because no progress was made popping items off the manifest.
+        ManifestHadNoProgress,
     }
 
     /// A request sent to the queue.

--- a/crates/abq_utils/src/net_protocol.rs
+++ b/crates/abq_utils/src/net_protocol.rs
@@ -324,6 +324,8 @@ pub mod workers {
         FailOnTestName(String),
         /// A worker that errors before generating a manifest.
         NeverReturnManifest,
+        /// A worker that hangs when the test run starts.
+        HangOnTestStart,
         /// A worker that errors when a test of a name is received, never returning a result.
         NeverReturnOnTest(String),
         /// A worker that panics in a section of ABQ code.

--- a/crates/abq_workers/src/assigned_run.rs
+++ b/crates/abq_workers/src/assigned_run.rs
@@ -1,0 +1,73 @@
+use abq_utils::net_protocol::{entity::Entity, queue::InvokeWork};
+use async_trait::async_trait;
+use serde_derive::{Deserialize, Serialize};
+
+/// The test run a worker should ask for work on.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum AssignedRun {
+    /// This worker is connecting for a fresh run, and should fetch tests online.
+    Fresh { should_generate_manifest: bool },
+    /// This worker is connecting for a retry, and should fetch its manifest from the queue once.
+    Retry,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AssignedRunStatus {
+    RunUnknown,
+    Run(AssignedRun),
+    AlreadyDone {
+        exit_code: abq_utils::exit::ExitCode,
+    },
+}
+
+impl AssignedRunStatus {
+    /// Returns true iff this is the first time the run was ever introduced.
+    pub fn freshly_created(&self) -> bool {
+        matches!(
+            self,
+            AssignedRunStatus::Run(AssignedRun::Fresh {
+                should_generate_manifest: true
+            })
+        )
+    }
+}
+
+#[async_trait]
+pub trait GetAssignedRun {
+    async fn get_assigned_run(&self, entity: Entity, invoke_work: &InvokeWork)
+        -> AssignedRunStatus;
+}
+
+#[cfg(test)]
+pub(crate) mod fake {
+    use abq_utils::net_protocol::{entity::Entity, queue::InvokeWork};
+    use async_trait::async_trait;
+
+    use crate::GetAssignedRun;
+
+    use super::AssignedRunStatus;
+
+    pub struct MockGetAssignedRun<F> {
+        status: F,
+    }
+
+    impl<F> MockGetAssignedRun<F> {
+        pub fn new(status: F) -> Self {
+            Self { status }
+        }
+    }
+
+    #[async_trait]
+    impl<F> GetAssignedRun for MockGetAssignedRun<F>
+    where
+        F: Fn() -> AssignedRunStatus + Send + Sync,
+    {
+        async fn get_assigned_run(
+            &self,
+            _entity: Entity,
+            _invoke_work: &InvokeWork,
+        ) -> AssignedRunStatus {
+            (self.status)()
+        }
+    }
+}

--- a/crates/abq_workers/src/lib.rs
+++ b/crates/abq_workers/src/lib.rs
@@ -1,3 +1,4 @@
+mod assigned_run;
 mod liveness;
 pub mod negotiate;
 pub mod results_handler;
@@ -8,3 +9,4 @@ pub mod workers;
 
 pub use abq_generic_test_runner::DEFAULT_PROTOCOL_VERSION_TIMEOUT;
 pub use abq_generic_test_runner::DEFAULT_RUNNER_TEST_TIMEOUT;
+pub use assigned_run::{AssignedRun, AssignedRunStatus, GetAssignedRun};

--- a/crates/abq_workers/src/runner_strategy.rs
+++ b/crates/abq_workers/src/runner_strategy.rs
@@ -21,10 +21,10 @@ use futures::FutureExt;
 use tracing::instrument;
 
 use crate::{
-    negotiate::AssignedRun,
     results_handler::{MultiplexingResultsHandler, QueueResultsSender},
     test_fetching,
     workers::{GetInitContext, InitContextResult, NotifyManifest, NotifyMaterialTestsAllRun},
+    AssignedRun,
 };
 
 pub struct RunnerStrategy {

--- a/crates/abq_workers/src/workers.rs
+++ b/crates/abq_workers/src/workers.rs
@@ -877,6 +877,7 @@ mod test {
         GetNextTests, InitContextResult, NotifyManifest, NotifyMaterialTestsAllRun, TestsFetcher,
         WorkerContext, WorkerPool,
     };
+    use crate::assigned_run::fake::MockGetAssignedRun;
     use crate::negotiate::QueueNegotiator;
     use crate::runner_strategy::{self, RunnerStrategy};
     use crate::workers::{WorkerPoolConfig, WorkersExitStatus};
@@ -1366,7 +1367,7 @@ mod test {
             shutdown_rx,
             "0.0.0.0:0".parse().unwrap(),
             "0.0.0.0:0".parse().unwrap(),
-            |_, _| panic!("should not ask for assigned run in this test"),
+            MockGetAssignedRun::new(|| panic!("should not ask for assigned run in this test")),
         )
         .await;
 

--- a/crates/abq_workers/src/workers.rs
+++ b/crates/abq_workers/src/workers.rs
@@ -644,6 +644,11 @@ async fn test_like_runner_exec_loop(
     runner_meta: RunnerMeta,
     mut results_handler: ResultsHandler,
 ) -> Option<Result<TestRunnerExit, GenericRunnerError>> {
+    if matches!(&runner, TestLikeRunner::HangOnTestStart) {
+        tokio::time::sleep(Duration::from_secs(60 * 60 * 24)).await;
+        unreachable!();
+    }
+
     'tests_done: loop {
         let NextWorkBundle { work, eow } = match tests_fetcher.get_next_tests().await {
             Ok(bundle) => bundle,


### PR DESCRIPTION
Presently, active runs can reach a state where all associated workers die, and no progress is made on the test suite, but the test suite sticks around in the queue memory. Since such runs may not be returned to at all, we'd like to diminish the amount of pressure they might place on a running queue.

This series of patches addresses the problem by running a job every hour that checks whether test runs have had any progress in their manifest. If either

- there is no manifest associated with the run after an hour, or
- no more items have been popped off the manifest since the last time progress was checked

then the run will be cancelled. If progress has been made, or the run was already done, the run is left untouched. If progress has been made and the run is not yet done, a job to check the progress again later is re-enqueued.

In the future, we'll likely want to adjust the behavior to not outright cancel a job, but to admit some way to re-launch the job from the last failure state.