### PR TITLE
Build releases as musl-only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,6 @@ dependencies = [
  "indicatif",
  "indoc",
  "insta",
- "mimalloc",
  "nix",
  "ntest",
  "num_cpus",
@@ -1576,16 +1575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,15 +1660,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]

--- a/crates/abq_cli/Cargo.toml
+++ b/crates/abq_cli/Cargo.toml
@@ -43,9 +43,6 @@ tracing-appender.workspace = true
 
 indoc.workspace = true
 
-[target.x86_64-unknown-linux-musl.dependencies]
-mimalloc = "0.1.34"
-
 [dev-dependencies]
 abq_utils = { path = "../abq_utils", features = ["expose-native-protocols"] }
 abq_test_utils = { path = "../abq_test_support/abq_test_utils" }

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -39,10 +39,6 @@ use crate::{
     reporting::StdoutPreferences,
 };
 
-#[cfg(all(target_arch = "x86_64", target_env = "musl"))]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 fn main() -> anyhow::Result<()> {
     let exit_code = abq_main()?;
     std::process::exit(exit_code.get());


### PR DESCRIPTION
ABQ queues can suffer high memory utilization when there are a high number of concurrent requests, which have large payload sizes, presumably due to the ephemeral nature of allocations and increased heap fragmentation. The best behavior for a synthetic, but pathological workload appears to be with a statically-linked musl build, using the default musl allocator.

- [glibc allocator](https://app.datadoghq.com/dashboard/hhb-h26-vmw/abq-queue-monitors?tpl_var_host%5B0%5D=i-06d18347d4cbf8dda&from_ts=1680718736220&to_ts=1680721268896&live=false)

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/20735482/230198732-784f4728-4c3e-406a-8e2c-d0e527f6a7dc.png">


- [jemalloc debug allocator](https://app.datadoghq.com/dashboard/hhb-h26-vmw/abq-queue-monitors?index=&tpl_var_host%5B0%5D=i-0bd039fafb3930233&from_ts=1680717778542&to_ts=1680720455725&live=false)

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/20735482/230198839-63a531f1-5dd0-45be-913a-2679615bc721.png">


- [jemalloc](https://app.datadoghq.com/dashboard/hhb-h26-vmw/abq-queue-monitors?index=&tpl_var_host%5B0%5D=i-08960f6a8c02daa9e&from_ts=1680722402333&to_ts=1680723596417&live=false)

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/20735482/230198922-b958be01-a29e-496c-8ef1-1ff30db42592.png">


- [mimalloc allocator](https://app.datadoghq.com/dashboard/hhb-h26-vmw/abq-queue-monitors?index=&tpl_var_host%5B0%5D=i-016e1dc9cf6d8d02b&from_ts=1680723024490&to_ts=1680724203364&live=false)

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/20735482/230199003-c35178b0-bcda-4163-9cfc-c5d7eda40aa7.png">
