### PR TITLE
Minor fixes for remote storage to s3

### DIFF
--- a/crates/abq_queue/src/persistence/manifest/fs.rs
+++ b/crates/abq_queue/src/persistence/manifest/fs.rs
@@ -230,7 +230,7 @@ mod test {
                         assert_eq!(run_id.0, "run-id");
                         assert_eq!(path, tempdir_path.join("run-id.manifest.json"));
                         let buf = std::fs::read_to_string(path).unwrap();
-                        let loaded_view = serde_json::from_slice(&buf.as_bytes()).unwrap();
+                        let loaded_view = serde_json::from_slice(buf.as_bytes()).unwrap();
                         assert_eq!(view, loaded_view);
                         Ok(())
                     }

--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -31,6 +31,22 @@ pub enum PersistenceKind {
     Results,
 }
 
+impl PersistenceKind {
+    fn kind_str(&self) -> &'static str {
+        match self {
+            Self::Manifest => "manifest",
+            Self::Results => "results",
+        }
+    }
+
+    fn file_extension(&self) -> &'static str {
+        match self {
+            Self::Manifest => "json",
+            Self::Results => "jsonl",
+        }
+    }
+}
+
 #[async_trait]
 pub trait RemotePersistence {
     async fn store(&self, kind: PersistenceKind, run_id: &RunId, data: Vec<u8>)

--- a/crates/abq_queue/src/persistence/remote/custom.rs
+++ b/crates/abq_queue/src/persistence/remote/custom.rs
@@ -57,10 +57,6 @@ impl CustomPersister {
             Action::Load => "load",
             Action::Store => "store",
         };
-        let kind = match kind {
-            PersistenceKind::Manifest => "manifest",
-            PersistenceKind::Results => "results",
-        };
 
         let std::process::Output {
             status,
@@ -69,7 +65,7 @@ impl CustomPersister {
         } = tokio::process::Command::new(&self.command)
             .args(&self.head_args)
             .arg(action)
-            .arg(kind)
+            .arg(kind.kind_str())
             .arg(run_id.to_string())
             .arg(path)
             .output()


### PR DESCRIPTION
- [Persist manifests to s3 from disk](https://github.com/rwx-research/abq/commit/cd5c23c1edc947b38f76bf739adce95c406fde7b)

- [Include manifest/results file extension in s3 remote](https://github.com/rwx-research/abq/commit/537a5ca577be4cebfb11549c655e8d7ed4fb461e)