### PR TITLE
Persist results in s3

### DIFF
--- a/crates/abq_cli/src/instance.rs
+++ b/crates/abq_cli/src/instance.rs
@@ -49,13 +49,14 @@ pub async fn start_abq_forever(
     let manifests_path = tempfile::tempdir().expect("unable to create a temporary file");
     let persist_manifest = persistence::manifest::FilesystemPersistor::new_shared(
         manifests_path.path(),
-        remote_persistence,
+        remote_persistence.clone(),
     );
 
     let results_path = tempfile::tempdir().expect("unable to create a temporary file");
     let persist_results = persistence::results::FilesystemPersistor::new_shared(
         results_path.path(),
         RESULTS_PERSISTENCE_LRU_CAPACITY,
+        remote_persistence,
     );
 
     let run_timeout_strategy = RunTimeoutStrategy::RUN_BASED;
@@ -208,8 +209,11 @@ impl AbqInstance {
         );
 
         let results_path = tempfile::tempdir().expect("unable to create a temporary file");
-        let persist_results =
-            persistence::results::FilesystemPersistor::new_shared(results_path.path(), 10);
+        let persist_results = persistence::results::FilesystemPersistor::new_shared(
+            results_path.path(),
+            10,
+            NoopPersister,
+        );
 
         let mut config = QueueConfig::new(persist_manifest, persist_results);
         config.server_options = ServerOptions::new(server_auth, server_tls);

--- a/crates/abq_queue/src/persistence/manifest.rs
+++ b/crates/abq_queue/src/persistence/manifest.rs
@@ -34,6 +34,10 @@ impl ManifestView {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
     fn get_partition_for_entity(self, entity_tag: Tag) -> Vec<WorkerTest> {
         let Self {
             mut items,

--- a/crates/abq_queue/src/persistence/manifest.rs
+++ b/crates/abq_queue/src/persistence/manifest.rs
@@ -38,6 +38,10 @@ impl ManifestView {
         self.items.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
     fn get_partition_for_entity(self, entity_tag: Tag) -> Vec<WorkerTest> {
         let Self {
             mut items,

--- a/crates/abq_queue/src/persistence/results.rs
+++ b/crates/abq_queue/src/persistence/results.rs
@@ -185,14 +185,14 @@ mod test {
         },
     };
 
-    use crate::persistence::results::EligibleForRemoteDump;
+    use crate::persistence::{remote, results::EligibleForRemoteDump};
 
     use super::{fs::FilesystemPersistor, ResultsPersistedCell};
 
     #[tokio::test]
     async fn retrieve_is_none_while_pending() {
         let tempdir = tempfile::tempdir().unwrap();
-        let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1);
+        let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote::NoopPersister);
 
         let cell = ResultsPersistedCell::new(RunId::unique());
         cell.0.processing.fetch_add(1, atomic::ORDERING);
@@ -203,7 +203,7 @@ mod test {
     #[tokio::test]
     async fn retrieve_is_some_when_no_pending() {
         let tempdir = tempfile::tempdir().unwrap();
-        let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1);
+        let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote::NoopPersister);
 
         let cell = ResultsPersistedCell::new(RunId::unique());
 
@@ -216,7 +216,7 @@ mod test {
     #[tokio::test]
     async fn retrieve_is_linearized() {
         let tempdir = tempfile::tempdir().unwrap();
-        let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1);
+        let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote::NoopPersister);
 
         let cell = ResultsPersistedCell::new(RunId::unique());
 

--- a/crates/abq_queue/src/persistence/results.rs
+++ b/crates/abq_queue/src/persistence/results.rs
@@ -75,7 +75,7 @@ struct CellInner {
 /// This is a hint as to whether or not the remote can be hit. The remote will only actually be
 /// persisted to if there are no additional pending local persistence operations after a local
 /// persistence operation completes.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum EligibleForRemoteDump {
     Yes,
     No,

--- a/crates/abq_queue/src/persistence/results/fs.rs
+++ b/crates/abq_queue/src/persistence/results/fs.rs
@@ -15,6 +15,8 @@ use tokio::{
     sync::Mutex,
 };
 
+use crate::persistence::remote::{PersistenceKind, RemotePersister};
+
 use super::{ArcResult, PersistResults, SharedPersistResults};
 
 /// A concurrent LRU cache of open file descriptors.
@@ -48,18 +50,28 @@ impl FdCache {
 pub struct FilesystemPersistor {
     root: PathBuf,
     fds: FdCache,
+    remote: RemotePersister,
 }
 
 impl FilesystemPersistor {
-    pub fn new(root: impl Into<PathBuf>, lru_capacity: usize) -> Self {
+    pub fn new(
+        root: impl Into<PathBuf>,
+        lru_capacity: usize,
+        remote: impl Into<RemotePersister>,
+    ) -> Self {
         Self {
             root: root.into(),
             fds: FdCache::new(lru_capacity),
+            remote: remote.into(),
         }
     }
 
-    pub fn new_shared(root: impl Into<PathBuf>, lru_capacity: usize) -> SharedPersistResults {
-        SharedPersistResults(Box::new(Self::new(root, lru_capacity)))
+    pub fn new_shared(
+        root: impl Into<PathBuf>,
+        lru_capacity: usize,
+        remote: impl Into<RemotePersister>,
+    ) -> SharedPersistResults {
+        SharedPersistResults(Box::new(Self::new(root, lru_capacity, remote)))
     }
 
     fn get_path(&self, run_id: &RunId) -> PathBuf {
@@ -99,7 +111,21 @@ impl PersistResults for FilesystemPersistor {
         Ok(())
     }
 
-    async fn dump_to_remote(&self, _run_id: &RunId) -> ArcResult<()> {
+    async fn dump_to_remote(&self, run_id: &RunId) -> ArcResult<()> {
+        let path = self.get_path(run_id);
+        let fi = self.fds.get_or_insert(path.clone()).await?;
+
+        // Take an exclusive lock so that new results don't come in while we flush to the remote.
+        let fi = fi.lock().await;
+
+        // While we have this opportunity, also instruct the OS to totally sync all data to disk
+        // rather than keeping it possibly in memory.
+        fi.sync_all().await.located(here!())?;
+
+        self.remote
+            .store_from_disk(PersistenceKind::Results, run_id, &path)
+            .await?;
+
         Ok(())
     }
 
@@ -132,19 +158,27 @@ mod test {
 
     use abq_run_n_times::n_times;
     use abq_test_utils::wid;
-    use abq_utils::net_protocol::{
-        queue::AssociatedTestResults, results::ResultsLine::Results, runners::TestResult,
-        workers::RunId,
+    use abq_utils::{
+        error::ResultLocation,
+        net_protocol::{
+            queue::AssociatedTestResults,
+            results::ResultsLine::{self, Results},
+            runners::TestResult,
+            workers::RunId,
+        },
     };
-    use tokio::task::JoinSet;
+    use tokio::{runtime, task::JoinSet};
 
-    use crate::persistence::results::PersistResults;
+    use crate::persistence::{
+        remote::{self, PersistenceKind},
+        results::PersistResults,
+    };
 
     use super::FilesystemPersistor;
 
     #[test]
     fn get_path() {
-        let fs = FilesystemPersistor::new("/tmp", 1);
+        let fs = FilesystemPersistor::new("/tmp", 1, remote::NoopPersister);
         let run_id = RunId("run1".to_owned());
         assert_eq!(
             fs.get_path(&run_id),
@@ -154,7 +188,7 @@ mod test {
 
     #[tokio::test]
     async fn dump_to_nonexistent_file_is_error() {
-        let fs = FilesystemPersistor::new("__zzz_this_is_not_a_subdir__", 1);
+        let fs = FilesystemPersistor::new("__zzz_this_is_not_a_subdir__", 1, remote::NoopPersister);
 
         let err = fs.dump(&RunId::unique(), Results(vec![])).await;
         assert!(err.is_err());
@@ -162,7 +196,7 @@ mod test {
 
     #[tokio::test]
     async fn load_from_nonexistent_file_is_error() {
-        let fs = FilesystemPersistor::new("__zzz_this_is_not_a_subdir__", 1);
+        let fs = FilesystemPersistor::new("__zzz_this_is_not_a_subdir__", 1, remote::NoopPersister);
 
         let err = fs.get_results(&RunId::unique()).await;
         assert!(err.is_err());
@@ -171,7 +205,7 @@ mod test {
     #[tokio::test]
     async fn dump_and_load_results() {
         let tempdir = tempfile::tempdir().unwrap();
-        let fs = FilesystemPersistor::new(tempdir.path(), 1);
+        let fs = FilesystemPersistor::new(tempdir.path(), 1, remote::NoopPersister);
 
         let run_id = RunId::unique();
 
@@ -194,7 +228,7 @@ mod test {
     #[tokio::test]
     async fn dump_and_load_results_multiple_times() {
         let tempdir = tempfile::tempdir().unwrap();
-        let fs = FilesystemPersistor::new(tempdir.path(), 1);
+        let fs = FilesystemPersistor::new(tempdir.path(), 1, remote::NoopPersister);
 
         let run_id = RunId::unique();
 
@@ -222,7 +256,7 @@ mod test {
     #[tokio::test]
     async fn dump_and_load_results_after_eviction() {
         let tempdir = tempfile::tempdir().unwrap();
-        let fs = FilesystemPersistor::new(tempdir.path(), 1);
+        let fs = FilesystemPersistor::new(tempdir.path(), 1, remote::NoopPersister);
 
         let run_id = RunId::unique();
 
@@ -251,7 +285,7 @@ mod test {
         const RUNS: usize = 10;
 
         let tempdir = tempfile::tempdir().unwrap();
-        let fs = FilesystemPersistor::new(tempdir.path(), RUNS);
+        let fs = FilesystemPersistor::new(tempdir.path(), RUNS, remote::NoopPersister);
 
         let mut join_set = JoinSet::new();
         let mut expected_for_run = Vec::with_capacity(RUNS);
@@ -290,5 +324,176 @@ mod test {
             let actual = fs.get_results(&run_id).await.unwrap().decode().unwrap();
             assert_eq!(actual, expected);
         }
+    }
+
+    #[tokio::test]
+    async fn dump_to_remote() {
+        let run_id = RunId("test-run-id".to_string());
+
+        let results = Results(vec![
+            AssociatedTestResults::fake(wid(1), vec![TestResult::fake()]),
+            AssociatedTestResults::fake(wid(2), vec![TestResult::fake()]),
+        ]);
+
+        let remote = remote::FakePersister::new(
+            |_, _, _| unreachable!(),
+            {
+                let results = results.clone();
+                move |kind, run_id, path| {
+                    assert_eq!(kind, PersistenceKind::Results);
+                    assert_eq!(run_id.0, "test-run-id");
+                    assert_eq!(path.file_name().unwrap(), "test-run-id.results.jsonl");
+                    let data = std::fs::read_to_string(path).unwrap();
+                    let read: ResultsLine = serde_json::from_str(&data).unwrap();
+                    assert_eq!(read, results);
+                    Ok(())
+                }
+            },
+            |_, _, _| unreachable!(),
+        );
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let fs = FilesystemPersistor::new(tempdir.path(), 10, remote);
+
+        fs.dump(&run_id, results).await.unwrap();
+
+        fs.dump_to_remote(&run_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dump_to_remote_err() {
+        let run_id = RunId("test-run-id".to_string());
+
+        let remote = remote::FakePersister::new(
+            |_, _, _| unreachable!(),
+            |_, _, _| Err("i failed").located(abq_utils::here!()),
+            |_, _, _| unreachable!(),
+        );
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let fs = FilesystemPersistor::new(tempdir.path(), 10, remote);
+
+        let err = fs.dump_to_remote(&run_id).await.unwrap_err();
+
+        assert!(err.to_string().contains("i failed"));
+    }
+
+    #[tokio::test]
+    async fn dump_to_remote_run_id_does_not_exist() {
+        let run_id = RunId("test-run-id".to_string());
+
+        // The remote should see the results, but the results will be empty.
+        let remote = remote::FakePersister::new(
+            |_, _, _| unreachable!(),
+            move |kind, run_id, path| {
+                assert_eq!(kind, PersistenceKind::Results);
+                assert_eq!(run_id.0, "test-run-id");
+                assert_eq!(path.file_name().unwrap(), "test-run-id.results.jsonl");
+                let data = std::fs::read_to_string(path).unwrap();
+                assert!(data.is_empty());
+                Ok(())
+            },
+            |_, _, _| unreachable!(),
+        );
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let fs = FilesystemPersistor::new(tempdir.path(), 10, remote);
+
+        fs.dump_to_remote(&run_id).await.unwrap();
+    }
+
+    #[n_times(100)]
+    #[test]
+    fn dump_to_remote_while_another_results_line_comes_in() {
+        // Race dumping to the remote and having another results line come in.
+        // Who wins is arbitrary - that's okay since we only want to enforce linearizability.
+        // However, we must make sure that the remote does not dump the results in a partial state
+        // are another results line writes to it.
+
+        let run_id = RunId("test-run-id".to_string());
+
+        let results1 = Results(vec![
+            AssociatedTestResults::fake(wid(1), vec![TestResult::fake()]),
+            AssociatedTestResults::fake(wid(2), vec![TestResult::fake()]),
+        ]);
+        let results2 = Results(vec![
+            AssociatedTestResults::fake(wid(3), vec![TestResult::fake()]),
+            AssociatedTestResults::fake(wid(4), vec![TestResult::fake()]),
+        ]);
+
+        let remote = remote::FakePersister::new(
+            |_, _, _| unreachable!(),
+            {
+                let (results1, results2) = (results1.clone(), results2.clone());
+                move |kind, run_id, path| {
+                    assert_eq!(kind, PersistenceKind::Results);
+                    assert_eq!(run_id.0, "test-run-id");
+                    assert_eq!(path.file_name().unwrap(), "test-run-id.results.jsonl");
+
+                    use std::io::BufRead;
+
+                    let mut fi = std::fs::File::open(path).unwrap();
+                    let lines = std::io::BufReader::new(&mut fi).lines();
+
+                    let data: Vec<ResultsLine> = lines
+                        .map(|line| serde_json::from_str(&line.unwrap()).unwrap())
+                        .collect();
+
+                    if data.len() == 1 {
+                        assert_eq!(data[0], results1);
+                    } else if data.len() == 2 {
+                        assert_eq!(data[0], results1);
+                        assert_eq!(data[1], results2);
+                    } else {
+                        panic!("unexpected number of lines: {:?}", data);
+                    }
+
+                    Ok(())
+                }
+            },
+            |_, _, _| unreachable!(),
+        );
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let fs = FilesystemPersistor::new(tempdir.path(), 10, remote);
+
+        let rt = || {
+            runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+        };
+
+        // Dump the first results line.
+        {
+            let fs = fs.clone();
+            let run_id = run_id.clone();
+            rt().block_on(async move {
+                fs.dump(&run_id, results1).await.unwrap();
+            });
+        }
+
+        // Start the two tasks on separate threads, since the remote persister check is blocking.
+        let dump_remote_task = {
+            let fs = fs.clone();
+            let run_id = run_id.clone();
+            move || rt().block_on(async move { fs.dump_to_remote(&run_id).await.unwrap() })
+        };
+
+        let dump_results_task =
+            move || rt().block_on(async move { fs.dump(&run_id, results2).await.unwrap() });
+
+        let dump_remote_thread;
+        let dump_results_thread;
+        if i % 2 == 0 {
+            dump_remote_thread = std::thread::spawn(dump_remote_task);
+            dump_results_thread = std::thread::spawn(dump_results_task);
+        } else {
+            dump_results_thread = std::thread::spawn(dump_results_task);
+            dump_remote_thread = std::thread::spawn(dump_remote_task);
+        }
+
+        dump_remote_thread.join().unwrap();
+        dump_results_thread.join().unwrap();
     }
 }

--- a/crates/abq_queue/src/persistence/results/fs.rs
+++ b/crates/abq_queue/src/persistence/results/fs.rs
@@ -20,6 +20,12 @@ use crate::persistence::remote::{PersistenceKind, RemotePersister};
 use super::{ArcResult, PersistResults, SharedPersistResults};
 
 /// A concurrent LRU cache of open file descriptors.
+//
+// TODO: reading and writing to results files asynchronously may be an expensive task,
+// given that results file may be quite large. Would it be better to use [std::fs::File]
+// and spawn off a blocking tasks instead?
+//
+//     https://docs.rs/tokio/latest/tokio/fs/index.html#usage
 #[derive(Clone)]
 struct FdCache(moka::future::Cache<PathBuf, Arc<Mutex<File>>>);
 

--- a/crates/abq_queue/src/persistence/results/fs.rs
+++ b/crates/abq_queue/src/persistence/results/fs.rs
@@ -99,6 +99,10 @@ impl PersistResults for FilesystemPersistor {
         Ok(())
     }
 
+    async fn dump_to_remote(&self, _run_id: &RunId) -> ArcResult<()> {
+        Ok(())
+    }
+
     async fn get_results(&self, run_id: &RunId) -> ArcResult<OpaqueLazyAssociatedTestResults> {
         let path = self.get_path(run_id);
 

--- a/crates/abq_queue/src/persistence/results/in_memory.rs
+++ b/crates/abq_queue/src/persistence/results/in_memory.rs
@@ -35,6 +35,10 @@ impl PersistResults for InMemoryPersistor {
         Ok(())
     }
 
+    async fn dump_to_remote(&self, _run_id: &RunId) -> ArcResult<()> {
+        Ok(())
+    }
+
     async fn get_results(&self, run_id: &RunId) -> ArcResult<OpaqueLazyAssociatedTestResults> {
         let results = self.results.read().await;
         let json_lines = results

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -275,7 +275,7 @@ fn sort_results_owned(results: &mut [FlatResult<'_>]) -> Vec<(u32, String)> {
         .collect()
 }
 
-fn flatten_queue_results<'a>(
+fn flatten_queue_results(
     results: impl std::borrow::Borrow<OpaqueLazyAssociatedTestResults>,
 ) -> (Vec<(u32, String)>, Summary) {
     let results = results.borrow();

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -89,8 +89,11 @@ impl Default for Server {
         );
 
         let results_path = tempfile::tempdir().unwrap();
-        let persist_results =
-            persistence::results::FilesystemPersistor::new_shared(results_path.path(), 10);
+        let persist_results = persistence::results::FilesystemPersistor::new_shared(
+            results_path.path(),
+            10,
+            persistence::remote::NoopPersister,
+        );
 
         let config = QueueConfig::new(persist_manifest, persist_results);
         let deps = QueueExtDeps {


### PR DESCRIPTION
Implements persistence of results to a remote persistence task.

Results are only persisted to a remote when
- there are no pending results-persistence tasks left in the queue
- the initial manifest is already complete

This is to avoid starvation by way of continuously persisting to the remote.