### PR TITLE
Load missing manifests from remotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "fs4",
  "futures",
  "indoc",
  "insta",
@@ -1166,8 +1167,10 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea55201cc351fdb478217c0fb641b59813da9b4efe4c414a9d8f989a657d149"
 dependencies = [
+ "async-trait",
  "libc",
  "rustix 0.35.13",
+ "tokio",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ pin-project-lite = "0.2.9"
 
 parking_lot = "0.12.1"
 moka = { version = "0.10.0", features = ["future"] }
+fs4 = { version = "0.6.3", features = ["tokio-async"] }
 fnv = "1.0.7"
 
 signal-hook = "0.3.15"
@@ -78,7 +79,6 @@ derive_more = "0.99.17"
 insta = { version = "1.29.0", features = ["json", "redactions"] }
 paste = "1.0.12"
 
-fs4 = "0.6.3"
 tempfile = "3.4.0"
 tracing-test = { version = "0.2.4", features = ["no-env-filter"] }
 

--- a/crates/abq_cli/src/args.rs
+++ b/crates/abq_cli/src/args.rs
@@ -13,10 +13,13 @@ use abq_utils::{
 use clap::{ArgGroup, Parser, Subcommand};
 
 use crate::{
-    instance::remote_persistence::{
-        RemotePersistenceStrategy, ENV_REMOTE_PERSISTENCE_COMMAND,
-        ENV_REMOTE_PERSISTENCE_S3_BUCKET, ENV_REMOTE_PERSISTENCE_S3_KEY_PREFIX,
-        ENV_REMOTE_PERSISTENCE_STRATEGY,
+    instance::{
+        local_persistence::{ENV_PERSISTED_MANIFESTS_DIR, ENV_PERSISTED_RESULTS_DIR},
+        remote_persistence::{
+            RemotePersistenceStrategy, ENV_REMOTE_PERSISTENCE_COMMAND,
+            ENV_REMOTE_PERSISTENCE_S3_BUCKET, ENV_REMOTE_PERSISTENCE_S3_KEY_PREFIX,
+            ENV_REMOTE_PERSISTENCE_STRATEGY,
+        },
     },
     reporting::{ColorPreference, ReporterKind},
 };
@@ -121,6 +124,16 @@ pub enum Command {
         /// If provided, must also provide `--tls-cert`.
         #[clap(long, requires("tls_cert"))]
         tls_key: Option<PathBuf>,
+
+        /// The directory persisted manifests should be written to.
+        /// If unspecified, a temporary directory will be used.
+        #[clap(long, required = false, env(ENV_PERSISTED_MANIFESTS_DIR))]
+        persisted_manifests_dir: Option<PathBuf>,
+
+        /// The directory persisted results should be written to.
+        /// If unspecified, a temporary directory will be used.
+        #[clap(long, required = false, env(ENV_PERSISTED_RESULTS_DIR))]
+        persisted_results_dir: Option<PathBuf>,
 
         /// How files should be persisted to a remote location, if at all.{n}
         /// The default is that no remote persistence is performed, and instead results and

--- a/crates/abq_cli/src/instance/local_persistence.rs
+++ b/crates/abq_cli/src/instance/local_persistence.rs
@@ -1,0 +1,71 @@
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+
+use tempfile::TempDir;
+
+pub const ENV_PERSISTED_MANIFESTS_DIR: &str = "ABQ_PERSISTED_MANIFESTS_DIR";
+pub const ENV_PERSISTED_RESULTS_DIR: &str = "ABQ_PERISTED_RESULTS_DIR";
+
+pub struct LocalPersistenceConfig {
+    manifests_dir: Option<PathBuf>,
+    results_dir: Option<PathBuf>,
+}
+
+impl LocalPersistenceConfig {
+    pub fn new(manifests_dir: Option<PathBuf>, results_dir: Option<PathBuf>) -> Self {
+        Self {
+            manifests_dir,
+            results_dir,
+        }
+    }
+
+    pub fn build(self) -> io::Result<LocalPersistence> {
+        let Self {
+            manifests_dir,
+            results_dir,
+        } = self;
+
+        Ok(LocalPersistence {
+            manifests: PersistedDir::new(manifests_dir)?,
+            results: PersistedDir::new(results_dir)?,
+        })
+    }
+}
+
+pub struct LocalPersistence {
+    manifests: PersistedDir,
+    results: PersistedDir,
+}
+
+impl LocalPersistence {
+    pub fn manifests_dir(&self) -> &Path {
+        self.manifests.path()
+    }
+
+    pub fn results_dir(&self) -> &Path {
+        self.results.path()
+    }
+}
+
+enum PersistedDir {
+    Configured(PathBuf),
+    Temp(TempDir),
+}
+
+impl PersistedDir {
+    pub fn new(dir: Option<PathBuf>) -> io::Result<Self> {
+        match dir {
+            Some(dir) => Ok(Self::Configured(dir)),
+            None => Ok(Self::Temp(TempDir::new()?)),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Configured(dir) => dir,
+            Self::Temp(dir) => dir.path(),
+        }
+    }
+}

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -35,7 +35,11 @@ use tracing::{metadata::LevelFilter, Subscriber};
 use tracing_subscriber::{fmt, prelude::*, registry, EnvFilter, Registry};
 
 use crate::{
-    args::Token, health::HealthCheckKind, instance::remote_persistence::RemotePersistenceConfig,
+    args::Token,
+    health::HealthCheckKind,
+    instance::{
+        local_persistence::LocalPersistenceConfig, remote_persistence::RemotePersistenceConfig,
+    },
     reporting::StdoutPreferences,
 };
 
@@ -230,6 +234,8 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             admin_token,
             tls_cert,
             tls_key,
+            persisted_results_dir,
+            persisted_manifests_dir,
             remote_persistence_strategy,
             remote_persistence_command,
             remote_persistence_s3_bucket,
@@ -257,6 +263,9 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
                 _ => unreachable!("Mutual dependency of TLS config should have been caught by clap during arg parsing!"),
             };
 
+            let local_persistence_config =
+                LocalPersistenceConfig::new(persisted_results_dir, persisted_manifests_dir);
+
             let remote_persistence_config = RemotePersistenceConfig::new(
                 remote_persistence_strategy,
                 remote_persistence_command,
@@ -271,6 +280,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
                 work_port,
                 negotiator_port,
                 ServerOptions::new(server_auth, server_tls),
+                local_persistence_config,
                 remote_persistence_config,
             )
             .await?;

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -264,7 +264,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             };
 
             let local_persistence_config =
-                LocalPersistenceConfig::new(persisted_results_dir, persisted_manifests_dir);
+                LocalPersistenceConfig::new(persisted_manifests_dir, persisted_results_dir);
 
             let remote_persistence_config = RemotePersistenceConfig::new(
                 remote_persistence_strategy,

--- a/crates/abq_queue/Cargo.toml
+++ b/crates/abq_queue/Cargo.toml
@@ -14,6 +14,7 @@ serde_json.workspace = true
 parking_lot.workspace = true
 moka.workspace = true
 tempfile.workspace = true
+fs4.workspace = true
 
 static_assertions.workspace = true
 

--- a/crates/abq_queue/src/persistence/manifest/fs.rs
+++ b/crates/abq_queue/src/persistence/manifest/fs.rs
@@ -250,7 +250,6 @@ mod test {
         let fs = FilesystemPersistor::new(
             tempdir.path(),
             FakePersister::new(
-                |_, _, _| unreachable!(),
                 {
                     let view = view.clone();
                     move |kind, run_id, path| {
@@ -285,7 +284,6 @@ mod test {
         let fs = FilesystemPersistor::new(
             tempdir.path(),
             FakePersister::new(
-                |_, _, _| unreachable!(),
                 |_, _, _| Err("i failed".located(here!())),
                 |_, _, _| unreachable!(),
             ),

--- a/crates/abq_queue/src/persistence/manifest/fs.rs
+++ b/crates/abq_queue/src/persistence/manifest/fs.rs
@@ -90,10 +90,9 @@ impl FilesystemPersistor {
             }
         };
 
-        let r = tokio::task::spawn_blocking(load_task)
+        tokio::task::spawn_blocking(load_task)
             .await
-            .located(here!())?;
-        r
+            .located(here!())?
     }
 
     async fn load_manifest_from_disk(&self, locked_file: LockedFile) -> Result<ManifestView> {
@@ -485,7 +484,7 @@ mod test {
             let fs = fs.clone();
             let run_id = run_id.clone();
 
-            let runner = runners[i].clone();
+            let runner = runners[i];
             let test = tests[i].clone();
 
             join_set.spawn(async move {

--- a/crates/abq_queue/src/persistence/manifest/fs.rs
+++ b/crates/abq_queue/src/persistence/manifest/fs.rs
@@ -147,7 +147,7 @@ impl PersistentManifest for FilesystemPersistor {
         };
 
         // Cede control to the remote persister so it can read from the path, while we still have
-        // exlusive access to the file.
+        // exclusive access to the file.
         {
             let path = self.get_path(run_id);
             self.remote

--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -23,6 +23,8 @@ pub use custom::CustomPersister;
 #[cfg(test)]
 mod fake;
 #[cfg(test)]
+pub use fake::unreachable as fake_unreachable;
+#[cfg(test)]
 pub use fake::FakePersister;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -96,7 +98,7 @@ impl RemotePersister {
         self.0.store_from_disk(kind, run_id, from_local_path).await
     }
 
-    pub async fn load(
+    pub async fn load_to_disk(
         &self,
         kind: PersistenceKind,
         run_id: &RunId,

--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -59,7 +59,7 @@ pub trait RemotePersistence {
 
     /// Loads a file from the remote persistence to the local filesystem.
     /// The given local path must have all intermediate directories already created.
-    async fn load(
+    async fn load_to_disk(
         &self,
         kind: PersistenceKind,
         run_id: &RunId,
@@ -102,6 +102,6 @@ impl RemotePersister {
         run_id: &RunId,
         into_local_path: &Path,
     ) -> OpaqueResult<()> {
-        self.0.load(kind, run_id, into_local_path).await
+        self.0.load_to_disk(kind, run_id, into_local_path).await
     }
 }

--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -49,9 +49,6 @@ impl PersistenceKind {
 
 #[async_trait]
 pub trait RemotePersistence {
-    async fn store(&self, kind: PersistenceKind, run_id: &RunId, data: Vec<u8>)
-        -> OpaqueResult<()>;
-
     /// Stores a file from the local filesystem to the remote persistence.
     async fn store_from_disk(
         &self,
@@ -88,15 +85,6 @@ where
 impl RemotePersister {
     pub fn new(persister: impl RemotePersistence + Send + Sync + 'static) -> RemotePersister {
         RemotePersister(Arc::new(Box::new(persister)))
-    }
-
-    pub async fn store(
-        &self,
-        kind: PersistenceKind,
-        run_id: &RunId,
-        data: Vec<u8>,
-    ) -> OpaqueResult<()> {
-        self.0.store(kind, run_id, data).await
     }
 
     pub async fn store_from_disk(

--- a/crates/abq_queue/src/persistence/remote/custom.rs
+++ b/crates/abq_queue/src/persistence/remote/custom.rs
@@ -86,7 +86,12 @@ impl CustomPersister {
 
 #[async_trait]
 impl RemotePersistence for CustomPersister {
-    async fn load(&self, kind: PersistenceKind, run_id: &RunId, path: &Path) -> OpaqueResult<()> {
+    async fn load_to_disk(
+        &self,
+        kind: PersistenceKind,
+        run_id: &RunId,
+        path: &Path,
+    ) -> OpaqueResult<()> {
         self.call(Action::Load, kind, run_id, path).await
     }
 
@@ -134,7 +139,7 @@ mod test {
         let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
 
         persister
-            .load(
+            .load_to_disk(
                 super::PersistenceKind::Manifest,
                 &RunId("run-id".to_string()),
                 Path::new("/tmp/foo"),
@@ -155,7 +160,7 @@ mod test {
         let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
 
         let err = persister
-            .load(
+            .load_to_disk(
                 super::PersistenceKind::Manifest,
                 &RunId("run-id".to_string()),
                 Path::new("/tmp/foo"),

--- a/crates/abq_queue/src/persistence/remote/custom.rs
+++ b/crates/abq_queue/src/persistence/remote/custom.rs
@@ -90,32 +90,6 @@ impl RemotePersistence for CustomPersister {
         self.call(Action::Load, kind, run_id, path).await
     }
 
-    /// Stores the bytes to a temporary path, then calls [Self::store_from_disk].
-    /// If possible, prefer to use [Self::store_from_disk] directly.
-    async fn store(
-        &self,
-        kind: PersistenceKind,
-        run_id: &RunId,
-        data: Vec<u8>,
-    ) -> OpaqueResult<()> {
-        let tempfile = tokio::task::spawn_blocking(tempfile::NamedTempFile::new)
-            .await
-            .located(here!())?
-            .located(here!())?;
-
-        let (tempfile, path) = tempfile.into_parts();
-        let mut tempfile = tokio::fs::File::from_std(tempfile);
-
-        use tokio::io::AsyncWriteExt;
-        tempfile.write_all(&data).await.located(here!())?;
-
-        let result = self.store_from_disk(kind, run_id, path.as_ref()).await;
-
-        drop(path);
-
-        result
-    }
-
     async fn store_from_disk(
         &self,
         kind: PersistenceKind,

--- a/crates/abq_queue/src/persistence/remote/fake.rs
+++ b/crates/abq_queue/src/persistence/remote/fake.rs
@@ -6,21 +6,18 @@ use async_trait::async_trait;
 use super::{PersistenceKind, RemotePersistence};
 
 #[derive(Clone)]
-pub struct FakePersister<OnStore, OnStoreFromDisk, OnLoad> {
-    on_store: OnStore,
+pub struct FakePersister<OnStoreFromDisk, OnLoad> {
     on_store_from_disk: OnStoreFromDisk,
     on_load: OnLoad,
 }
 
-impl<OnStore, OnStoreFromDisk, OnLoad> FakePersister<OnStore, OnStoreFromDisk, OnLoad>
+impl<OnStoreFromDisk, OnLoad> FakePersister<OnStoreFromDisk, OnLoad>
 where
-    OnStore: Fn(PersistenceKind, &RunId, Vec<u8>) -> OpaqueResult<()> + Send + Sync,
     OnStoreFromDisk: Fn(PersistenceKind, &RunId, &Path) -> OpaqueResult<()> + Send + Sync,
     OnLoad: Fn(PersistenceKind, &RunId, &Path) -> OpaqueResult<()> + Send + Sync,
 {
-    pub fn new(on_store: OnStore, on_store_from_disk: OnStoreFromDisk, on_load: OnLoad) -> Self {
+    pub fn new(on_store_from_disk: OnStoreFromDisk, on_load: OnLoad) -> Self {
         Self {
-            on_store,
             on_store_from_disk,
             on_load,
         }
@@ -28,24 +25,12 @@ where
 }
 
 #[async_trait]
-impl<OnStore, OnStoreFromDisk, OnLoad> RemotePersistence
-    for FakePersister<OnStore, OnStoreFromDisk, OnLoad>
+impl<OnStoreFromDisk, OnLoad> RemotePersistence for FakePersister<OnStoreFromDisk, OnLoad>
 where
-    OnStore:
-        Fn(PersistenceKind, &RunId, Vec<u8>) -> OpaqueResult<()> + Send + Sync + Clone + 'static,
     OnStoreFromDisk:
         Fn(PersistenceKind, &RunId, &Path) -> OpaqueResult<()> + Send + Sync + Clone + 'static,
     OnLoad: Fn(PersistenceKind, &RunId, &Path) -> OpaqueResult<()> + Send + Sync + Clone + 'static,
 {
-    async fn store(
-        &self,
-        kind: PersistenceKind,
-        run_id: &RunId,
-        data: Vec<u8>,
-    ) -> OpaqueResult<()> {
-        (self.on_store)(kind, run_id, data)
-    }
-
     async fn store_from_disk(
         &self,
         kind: PersistenceKind,

--- a/crates/abq_queue/src/persistence/remote/fake.rs
+++ b/crates/abq_queue/src/persistence/remote/fake.rs
@@ -40,7 +40,7 @@ where
         (self.on_store_from_disk)(kind, run_id, from_local_path)
     }
 
-    async fn load(
+    async fn load_to_disk(
         &self,
         kind: PersistenceKind,
         run_id: &RunId,

--- a/crates/abq_queue/src/persistence/remote/noop.rs
+++ b/crates/abq_queue/src/persistence/remote/noop.rs
@@ -29,7 +29,7 @@ impl RemotePersistence for NoopPersister {
         Ok(())
     }
 
-    async fn load(
+    async fn load_to_disk(
         &self,
         _kind: PersistenceKind,
         _run_id: &RunId,

--- a/crates/abq_queue/src/persistence/remote/noop.rs
+++ b/crates/abq_queue/src/persistence/remote/noop.rs
@@ -20,15 +20,6 @@ impl NoopPersister {
 
 #[async_trait]
 impl RemotePersistence for NoopPersister {
-    async fn store(
-        &self,
-        _kind: PersistenceKind,
-        _run_id: &RunId,
-        _data: Vec<u8>,
-    ) -> OpaqueResult<()> {
-        Ok(())
-    }
-
     async fn store_from_disk(
         &self,
         _kind: PersistenceKind,

--- a/crates/abq_queue/src/persistence/remote/s3.rs
+++ b/crates/abq_queue/src/persistence/remote/s3.rs
@@ -120,7 +120,7 @@ where
         Ok(())
     }
 
-    async fn load(
+    async fn load_to_disk(
         &self,
         kind: PersistenceKind,
         run_id: &RunId,
@@ -270,7 +270,7 @@ mod test {
 
         let manifest = NamedTempFile::new().unwrap();
 
-        s3.load(
+        s3.load_to_disk(
             PersistenceKind::Manifest,
             &RunId("test-run-id".to_owned()),
             manifest.path(),
@@ -325,7 +325,7 @@ mod test {
         let manifest = NamedTempFile::new().unwrap();
 
         let err = s3
-            .load(
+            .load_to_disk(
                 PersistenceKind::Manifest,
                 &RunId("test-run-id".to_owned()),
                 manifest.path(),

--- a/crates/abq_queue/src/persistence/remote/s3.rs
+++ b/crates/abq_queue/src/persistence/remote/s3.rs
@@ -104,20 +104,6 @@ impl<T> RemotePersistence for T
 where
     T: S3Impl + Clone + Send + Sync + 'static,
 {
-    async fn store(
-        &self,
-        kind: PersistenceKind,
-        run_id: &RunId,
-        data: Vec<u8>,
-    ) -> OpaqueResult<()> {
-        let key = build_key(self.key_prefix(), kind, run_id);
-        let body = ByteStream::from(data);
-
-        let _put_object = self.put(key, body).await.located(here!())?;
-
-        Ok(())
-    }
-
     async fn store_from_disk(
         &self,
         kind: PersistenceKind,
@@ -246,27 +232,6 @@ mod test {
     }
 
     #[tokio::test]
-    async fn store_okay() {
-        let s3 = S3Fake::new(
-            "bucket-prefix",
-            |key, body| {
-                assert_eq!(key, "bucket-prefix/test-run-id/manifest.json");
-                assert_eq!(body, b"manifest-body");
-                Ok(PutObjectOutput::builder().build())
-            },
-            |_| unreachable!(),
-        );
-
-        s3.store(
-            PersistenceKind::Manifest,
-            &RunId("test-run-id".to_owned()),
-            b"manifest-body".to_vec(),
-        )
-        .await
-        .unwrap();
-    }
-
-    #[tokio::test]
     async fn store_from_disk_okay() {
         let s3 = S3Fake::new(
             "bucket-prefix",
@@ -317,30 +282,6 @@ mod test {
         io::Read::read_to_end(&mut io::BufReader::new(manifest), &mut buf).unwrap();
 
         assert_eq!(buf, b"manifest-body");
-    }
-
-    #[tokio::test]
-    async fn store_error() {
-        let s3 = S3Fake::new(
-            "bucket-prefix",
-            |key, body| {
-                assert_eq!(key, "bucket-prefix/test-run-id/manifest.json");
-                assert_eq!(body, b"manifest-body");
-                Err(SdkError::timeout_error("timed out"))
-            },
-            |_| unreachable!(),
-        );
-
-        let err = s3
-            .store(
-                PersistenceKind::Manifest,
-                &RunId("test-run-id".to_owned()),
-                b"manifest-body".to_vec(),
-            )
-            .await
-            .unwrap_err();
-
-        assert!(err.to_string().contains("timed out"));
     }
 
     #[tokio::test]

--- a/crates/abq_queue/src/persistence/results.rs
+++ b/crates/abq_queue/src/persistence/results.rs
@@ -189,7 +189,7 @@ mod test {
     };
 
     use crate::persistence::{
-        remote::{self, PersistenceKind},
+        remote::{self, fake_unreachable, PersistenceKind},
         results::EligibleForRemoteDump,
     };
 
@@ -277,7 +277,7 @@ mod test {
 
     #[tokio::test]
     async fn execute_not_eligible_for_persistence_is_last() {
-        let remote = remote::FakePersister::new(|_, _, _| unreachable!(), |_, _, _| unreachable!());
+        let remote = remote::FakePersister::new(fake_unreachable, fake_unreachable);
 
         let tempdir = tempfile::tempdir().unwrap();
         let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote);
@@ -301,7 +301,7 @@ mod test {
 
     #[tokio::test]
     async fn execute_not_eligible_for_persistence_is_not_last() {
-        let remote = remote::FakePersister::new(|_, _, _| unreachable!(), |_, _, _| unreachable!());
+        let remote = remote::FakePersister::new(fake_unreachable, fake_unreachable);
 
         let tempdir = tempfile::tempdir().unwrap();
         let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote);
@@ -327,7 +327,7 @@ mod test {
 
     #[tokio::test]
     async fn execute_eligible_for_persistence_is_not_last() {
-        let remote = remote::FakePersister::new(|_, _, _| unreachable!(), |_, _, _| unreachable!());
+        let remote = remote::FakePersister::new(fake_unreachable, fake_unreachable);
 
         let tempdir = tempfile::tempdir().unwrap();
         let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote);
@@ -364,18 +364,22 @@ mod test {
                 let results = ResultsLine::Results(results.clone());
                 let set_remote = set_remote.clone();
                 move |kind, run_id, path| {
-                    assert_eq!(kind, PersistenceKind::Results);
-                    assert_eq!(run_id.0, "test-run-id");
-                    let data = std::fs::read_to_string(path).unwrap();
-                    let read: ResultsLine = serde_json::from_str(&data).unwrap();
-                    assert_eq!(read, results);
+                    let results = results.clone();
+                    let set_remote = set_remote.clone();
+                    async move {
+                        assert_eq!(kind, PersistenceKind::Results);
+                        assert_eq!(run_id.0, "test-run-id");
+                        let data = tokio::fs::read_to_string(path).await.unwrap();
+                        let read: ResultsLine = serde_json::from_str(&data).unwrap();
+                        assert_eq!(read, results);
 
-                    set_remote.store(true, atomic::ORDERING);
+                        set_remote.store(true, atomic::ORDERING);
 
-                    Ok(())
+                        Ok(())
+                    }
                 }
             },
-            |_, _, _| unreachable!(),
+            fake_unreachable,
         );
 
         let tempdir = tempfile::tempdir().unwrap();

--- a/crates/abq_queue/src/persistence/results.rs
+++ b/crates/abq_queue/src/persistence/results.rs
@@ -277,11 +277,7 @@ mod test {
 
     #[tokio::test]
     async fn execute_not_eligible_for_persistence_is_last() {
-        let remote = remote::FakePersister::new(
-            |_, _, _| unreachable!(),
-            |_, _, _| unreachable!(),
-            |_, _, _| unreachable!(),
-        );
+        let remote = remote::FakePersister::new(|_, _, _| unreachable!(), |_, _, _| unreachable!());
 
         let tempdir = tempfile::tempdir().unwrap();
         let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote);
@@ -305,11 +301,7 @@ mod test {
 
     #[tokio::test]
     async fn execute_not_eligible_for_persistence_is_not_last() {
-        let remote = remote::FakePersister::new(
-            |_, _, _| unreachable!(),
-            |_, _, _| unreachable!(),
-            |_, _, _| unreachable!(),
-        );
+        let remote = remote::FakePersister::new(|_, _, _| unreachable!(), |_, _, _| unreachable!());
 
         let tempdir = tempfile::tempdir().unwrap();
         let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote);
@@ -335,11 +327,7 @@ mod test {
 
     #[tokio::test]
     async fn execute_eligible_for_persistence_is_not_last() {
-        let remote = remote::FakePersister::new(
-            |_, _, _| unreachable!(),
-            |_, _, _| unreachable!(),
-            |_, _, _| unreachable!(),
-        );
+        let remote = remote::FakePersister::new(|_, _, _| unreachable!(), |_, _, _| unreachable!());
 
         let tempdir = tempfile::tempdir().unwrap();
         let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote);
@@ -372,7 +360,6 @@ mod test {
         let set_remote = Arc::new(AtomicBool::new(false));
 
         let remote = remote::FakePersister::new(
-            |_, _, _| unreachable!(),
             {
                 let results = ResultsLine::Results(results.clone());
                 let set_remote = set_remote.clone();

--- a/crates/abq_queue/src/persistence/results/fs.rs
+++ b/crates/abq_queue/src/persistence/results/fs.rs
@@ -173,10 +173,10 @@ mod test {
             workers::RunId,
         },
     };
-    use tokio::{runtime, task::JoinSet};
+    use tokio::task::JoinSet;
 
     use crate::persistence::{
-        remote::{self, PersistenceKind},
+        remote::{self, fake_unreachable, PersistenceKind},
         results::PersistResults,
     };
 
@@ -345,16 +345,19 @@ mod test {
             {
                 let results = results.clone();
                 move |kind, run_id, path| {
-                    assert_eq!(kind, PersistenceKind::Results);
-                    assert_eq!(run_id.0, "test-run-id");
-                    assert_eq!(path.file_name().unwrap(), "test-run-id.results.jsonl");
-                    let data = std::fs::read_to_string(path).unwrap();
-                    let read: ResultsLine = serde_json::from_str(&data).unwrap();
-                    assert_eq!(read, results);
-                    Ok(())
+                    let results = results.clone();
+                    async move {
+                        assert_eq!(kind, PersistenceKind::Results);
+                        assert_eq!(run_id.0, "test-run-id");
+                        assert_eq!(path.file_name().unwrap(), "test-run-id.results.jsonl");
+                        let data = tokio::fs::read_to_string(path).await.unwrap();
+                        let read: ResultsLine = serde_json::from_str(&data).unwrap();
+                        assert_eq!(read, results);
+                        Ok(())
+                    }
                 }
             },
-            |_, _, _| unreachable!(),
+            fake_unreachable,
         );
 
         let tempdir = tempfile::tempdir().unwrap();
@@ -370,8 +373,8 @@ mod test {
         let run_id = RunId("test-run-id".to_string());
 
         let remote = remote::FakePersister::new(
-            |_, _, _| Err("i failed").located(abq_utils::here!()),
-            |_, _, _| unreachable!(),
+            |_, _, _| async { Err("i failed").located(abq_utils::here!()) },
+            fake_unreachable,
         );
 
         let tempdir = tempfile::tempdir().unwrap();
@@ -388,15 +391,15 @@ mod test {
 
         // The remote should see the results, but the results will be empty.
         let remote = remote::FakePersister::new(
-            move |kind, run_id, path| {
+            move |kind, run_id, path| async move {
                 assert_eq!(kind, PersistenceKind::Results);
                 assert_eq!(run_id.0, "test-run-id");
                 assert_eq!(path.file_name().unwrap(), "test-run-id.results.jsonl");
-                let data = std::fs::read_to_string(path).unwrap();
+                let data = tokio::fs::read_to_string(path).await.unwrap();
                 assert!(data.is_empty());
                 Ok(())
             },
-            |_, _, _| unreachable!(),
+            fake_unreachable,
         );
 
         let tempdir = tempfile::tempdir().unwrap();
@@ -406,8 +409,8 @@ mod test {
     }
 
     #[n_times(100)]
-    #[test]
-    fn dump_to_remote_while_another_results_line_comes_in() {
+    #[tokio::test]
+    async fn dump_to_remote_while_another_results_line_comes_in() {
         // Race dumping to the remote and having another results line come in.
         // Who wins is arbitrary - that's okay since we only want to enforce linearizability.
         // However, we must make sure that the remote does not dump the results in a partial state
@@ -428,74 +431,67 @@ mod test {
             {
                 let (results1, results2) = (results1.clone(), results2.clone());
                 move |kind, run_id, path| {
-                    assert_eq!(kind, PersistenceKind::Results);
-                    assert_eq!(run_id.0, "test-run-id");
-                    assert_eq!(path.file_name().unwrap(), "test-run-id.results.jsonl");
+                    let (results1, results2) = (results1.clone(), results2.clone());
 
-                    use std::io::BufRead;
+                    async move {
+                        assert_eq!(kind, PersistenceKind::Results);
+                        assert_eq!(run_id.0, "test-run-id");
+                        assert_eq!(path.file_name().unwrap(), "test-run-id.results.jsonl");
 
-                    let mut fi = std::fs::File::open(path).unwrap();
-                    let lines = std::io::BufReader::new(&mut fi).lines();
+                        use tokio::io::AsyncBufReadExt;
 
-                    let data: Vec<ResultsLine> = lines
-                        .map(|line| serde_json::from_str(&line.unwrap()).unwrap())
-                        .collect();
+                        let mut fi = tokio::fs::File::open(path).await.unwrap();
+                        let mut lines = tokio::io::BufReader::new(&mut fi).lines();
 
-                    if data.len() == 1 {
-                        assert_eq!(data[0], results1);
-                    } else if data.len() == 2 {
-                        assert_eq!(data[0], results1);
-                        assert_eq!(data[1], results2);
-                    } else {
-                        panic!("unexpected number of lines: {:?}", data);
+                        let mut data: Vec<ResultsLine> = vec![];
+                        while let Some(line) = lines.next_line().await.unwrap() {
+                            data.push(serde_json::from_str(&line).unwrap());
+                        }
+
+                        if data.len() == 1 {
+                            assert_eq!(data[0], results1);
+                        } else if data.len() == 2 {
+                            assert_eq!(data[0], results1);
+                            assert_eq!(data[1], results2);
+                        } else {
+                            panic!("unexpected number of lines: {:?}", data);
+                        }
+
+                        Ok(())
                     }
-
-                    Ok(())
                 }
             },
-            |_, _, _| unreachable!(),
+            fake_unreachable,
         );
 
         let tempdir = tempfile::tempdir().unwrap();
         let fs = FilesystemPersistor::new(tempdir.path(), 10, remote);
 
-        let rt = || {
-            runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-        };
-
         // Dump the first results line.
         {
             let fs = fs.clone();
-            let run_id = run_id.clone();
-            rt().block_on(async move {
-                fs.dump(&run_id, results1).await.unwrap();
-            });
+            fs.dump(&run_id, results1).await.unwrap();
         }
 
         // Start the two tasks on separate threads, since the remote persister check is blocking.
         let dump_remote_task = {
             let fs = fs.clone();
             let run_id = run_id.clone();
-            move || rt().block_on(async move { fs.dump_to_remote(&run_id).await.unwrap() })
+            async move { fs.dump_to_remote(&run_id).await }
         };
 
-        let dump_results_task =
-            move || rt().block_on(async move { fs.dump(&run_id, results2).await.unwrap() });
+        let dump_results_task = { fs.dump(&run_id, results2) };
 
-        let dump_remote_thread;
-        let dump_results_thread;
+        let dump_remote_result;
+        let dump_results_result;
         if i % 2 == 0 {
-            dump_remote_thread = std::thread::spawn(dump_remote_task);
-            dump_results_thread = std::thread::spawn(dump_results_task);
+            (dump_remote_result, dump_results_result) =
+                tokio::join!(dump_remote_task, dump_results_task);
         } else {
-            dump_results_thread = std::thread::spawn(dump_results_task);
-            dump_remote_thread = std::thread::spawn(dump_remote_task);
+            (dump_results_result, dump_remote_result) =
+                tokio::join!(dump_remote_task, dump_results_task);
         }
-
-        dump_remote_thread.join().unwrap();
-        dump_results_thread.join().unwrap();
+        dump_remote_result.unwrap();
+        dump_results_result.unwrap();
     }
 }

--- a/crates/abq_queue/src/persistence/results/fs.rs
+++ b/crates/abq_queue/src/persistence/results/fs.rs
@@ -342,7 +342,6 @@ mod test {
         ]);
 
         let remote = remote::FakePersister::new(
-            |_, _, _| unreachable!(),
             {
                 let results = results.clone();
                 move |kind, run_id, path| {
@@ -371,7 +370,6 @@ mod test {
         let run_id = RunId("test-run-id".to_string());
 
         let remote = remote::FakePersister::new(
-            |_, _, _| unreachable!(),
             |_, _, _| Err("i failed").located(abq_utils::here!()),
             |_, _, _| unreachable!(),
         );
@@ -390,7 +388,6 @@ mod test {
 
         // The remote should see the results, but the results will be empty.
         let remote = remote::FakePersister::new(
-            |_, _, _| unreachable!(),
             move |kind, run_id, path| {
                 assert_eq!(kind, PersistenceKind::Results);
                 assert_eq!(run_id.0, "test-run-id");
@@ -428,7 +425,6 @@ mod test {
         ]);
 
         let remote = remote::FakePersister::new(
-            |_, _, _| unreachable!(),
             {
                 let (results1, results2) = (results1.clone(), results2.clone());
                 move |kind, run_id, path| {

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -168,7 +168,7 @@ impl RemotePersistence for InMemoryRemote {
 
     /// Loads a file from the remote persistence to the local filesystem.
     /// The given local path must have all intermediate directories already created.
-    async fn load(
+    async fn load_to_disk(
         &self,
         kind: PersistenceKind,
         run_id: &RunId,

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -136,12 +136,14 @@ struct InMemoryRemote(Arc<tokio::sync::Mutex<InMemoryRemoteInner>>);
 
 #[async_trait]
 impl RemotePersistence for InMemoryRemote {
-    async fn store(
+    /// Stores a file from the local filesystem to the remote persistence.
+    async fn store_from_disk(
         &self,
         kind: PersistenceKind,
         run_id: &RunId,
-        data: Vec<u8>,
+        from_local_path: &Path,
     ) -> OpaqueResult<()> {
+        let data = tokio::fs::read(from_local_path).await.unwrap();
         let mut inner = self.0.lock().await;
         match kind {
             PersistenceKind::Manifest => {
@@ -162,17 +164,6 @@ impl RemotePersistence for InMemoryRemote {
             }
         }
         Ok(())
-    }
-
-    /// Stores a file from the local filesystem to the remote persistence.
-    async fn store_from_disk(
-        &self,
-        kind: PersistenceKind,
-        run_id: &RunId,
-        from_local_path: &Path,
-    ) -> OpaqueResult<()> {
-        let data = tokio::fs::read(from_local_path).await.unwrap();
-        self.store(kind, run_id, data).await
     }
 
     /// Loads a file from the remote persistence to the local filesystem.


### PR DESCRIPTION
This patch supports loading manifests from remote persistence into the local persistence strategy, when appropriate.

The material implementation loads manifests into the local filesystem from a remote persistence. This is done by 
- taking an exclusive file lock (`flock`, `LOCK_EX`) when a manifest file is read from, or dumped to
- if upon reading the manifest file we see that it is empty, or corrupted, attempt to load the file descriptor from the remote persistence