### PR TITLE
Stub out loading test results from a remote

### DIFF
--- a/crates/abq_queue/src/persistence/remote/custom.rs
+++ b/crates/abq_queue/src/persistence/remote/custom.rs
@@ -29,6 +29,7 @@ pub struct CustomPersister {
     head_args: Vec<String>,
 }
 
+#[derive(Debug)]
 enum Action {
     Load,
     Store,
@@ -53,6 +54,8 @@ impl CustomPersister {
         run_id: &RunId,
         path: &Path,
     ) -> OpaqueResult<()> {
+        tracing::info!(?path, ?action, "calling with");
+
         let action = match action {
             Action::Load => "load",
             Action::Store => "store",

--- a/crates/abq_queue/src/persistence/results.rs
+++ b/crates/abq_queue/src/persistence/results.rs
@@ -209,7 +209,14 @@ mod test {
     #[tokio::test]
     async fn retrieve_is_some_when_no_pending() {
         let tempdir = tempfile::tempdir().unwrap();
-        let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote::NoopPersister);
+        let persistence = FilesystemPersistor::new_shared(
+            tempdir.path(),
+            1,
+            remote::FakePersister::new(fake_unreachable, |_, _, _| async {
+                // Load nothing new into the file
+                Ok(())
+            }),
+        );
 
         let cell = ResultsPersistedCell::new(RunId::unique());
 


### PR DESCRIPTION
If an open file descriptor for a test results file is now empty, we will fetch it from the remote.

This does not yet handle the case of loading a test results file from the remote to add more results.