### PR TITLE
Implement loading test results files from remote during result addition

### DIFF
--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -23,6 +23,8 @@ pub use custom::CustomPersister;
 #[cfg(test)]
 mod fake;
 #[cfg(test)]
+pub use fake::error as fake_error;
+#[cfg(test)]
 pub use fake::unreachable as fake_unreachable;
 #[cfg(test)]
 pub use fake::FakePersister;

--- a/crates/abq_queue/src/persistence/remote/fake.rs
+++ b/crates/abq_queue/src/persistence/remote/fake.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 use std::{future::Future, path::PathBuf};
 
+use abq_utils::error::ErrorLocation;
+use abq_utils::here;
 use abq_utils::{error::OpaqueResult, net_protocol::workers::RunId};
 use async_trait::async_trait;
 
@@ -15,6 +17,11 @@ pub struct FakePersister<OnStoreFromDisk, OnLoad> {
 #[track_caller]
 pub async fn unreachable(_x: PersistenceKind, _y: RunId, _z: PathBuf) -> OpaqueResult<()> {
     unreachable!()
+}
+
+#[track_caller]
+pub async fn error(_x: PersistenceKind, _y: RunId, _z: PathBuf) -> OpaqueResult<()> {
+    Err("error".located(here!()))
 }
 
 impl<OnStoreFromDisk, OnStoreFromDiskF, OnLoad, OnLoadF> FakePersister<OnStoreFromDisk, OnLoad>

--- a/crates/abq_queue/src/persistence/results.rs
+++ b/crates/abq_queue/src/persistence/results.rs
@@ -189,7 +189,7 @@ mod test {
     };
 
     use crate::persistence::{
-        remote::{self, fake_unreachable, PersistenceKind},
+        remote::{self, fake_error, fake_unreachable, PersistenceKind},
         results::EligibleForRemoteDump,
     };
 
@@ -284,7 +284,7 @@ mod test {
 
     #[tokio::test]
     async fn execute_not_eligible_for_persistence_is_last() {
-        let remote = remote::FakePersister::new(fake_unreachable, fake_unreachable);
+        let remote = remote::FakePersister::new(fake_unreachable, fake_error);
 
         let tempdir = tempfile::tempdir().unwrap();
         let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote);
@@ -308,7 +308,7 @@ mod test {
 
     #[tokio::test]
     async fn execute_not_eligible_for_persistence_is_not_last() {
-        let remote = remote::FakePersister::new(fake_unreachable, fake_unreachable);
+        let remote = remote::FakePersister::new(fake_unreachable, fake_error);
 
         let tempdir = tempfile::tempdir().unwrap();
         let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote);
@@ -334,7 +334,7 @@ mod test {
 
     #[tokio::test]
     async fn execute_eligible_for_persistence_is_not_last() {
-        let remote = remote::FakePersister::new(fake_unreachable, fake_unreachable);
+        let remote = remote::FakePersister::new(fake_unreachable, fake_error);
 
         let tempdir = tempfile::tempdir().unwrap();
         let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote);
@@ -386,7 +386,7 @@ mod test {
                     }
                 }
             },
-            fake_unreachable,
+            fake_error,
         );
 
         let tempdir = tempfile::tempdir().unwrap();

--- a/crates/abq_queue/src/persistence/results/fs.rs
+++ b/crates/abq_queue/src/persistence/results/fs.rs
@@ -830,10 +830,10 @@ mod test {
 
         let mut join_set = tokio::task::JoinSet::new();
 
-        for i in 0..N {
+        for results in other_results.iter() {
             let run_id = run_id.clone();
-            let results = other_results[i].clone();
             let fs = fs.clone();
+            let results = results.clone();
             join_set.spawn(async move {
                 fs.dump(&run_id, results).await.unwrap();
             });

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -22,8 +22,9 @@ use abq_queue::{
 use abq_test_utils::{artifacts_dir, assert_scoped_log, s};
 use abq_utils::{
     auth::{ClientAuthStrategy, User},
-    error::OpaqueResult,
+    error::{ErrorLocation, OpaqueResult},
     exit::ExitCode,
+    here,
     net_async::{ClientStream, ConfiguredClient},
     net_opt::ClientOptions,
     net_protocol::{
@@ -178,11 +179,17 @@ impl RemotePersistence for InMemoryRemote {
             let inner = self.0.lock().await;
             match kind {
                 PersistenceKind::Manifest => {
-                    let manifest = inner.manifests.get(run_id).unwrap();
+                    let manifest = inner
+                        .manifests
+                        .get(run_id)
+                        .ok_or_else(|| "manifest for entry missing".located(here!()))?;
                     serde_json::to_vec(manifest).unwrap()
                 }
                 PersistenceKind::Results => {
-                    let results = inner.results.get(run_id).unwrap();
+                    let results = inner
+                        .results
+                        .get(run_id)
+                        .ok_or_else(|| "results for entry missing".located(here!()))?;
                     serde_json::to_vec(results).unwrap()
                 }
             }


### PR DESCRIPTION
If a test result file is empty when we load it for adding test results, opportunistically attempt to fetch it from the remote. If the results file is not found, then we suppose it is fresh.