### PR TITLE
Implement a job to cleanup manifest files to the remote

### DIFF
--- a/crates/abq_queue/src/persistence.rs
+++ b/crates/abq_queue/src/persistence.rs
@@ -2,3 +2,6 @@ pub mod manifest;
 pub mod results;
 
 pub mod remote;
+
+mod offload;
+pub use offload::OffloadConfig;

--- a/crates/abq_queue/src/persistence/manifest/fs.rs
+++ b/crates/abq_queue/src/persistence/manifest/fs.rs
@@ -679,14 +679,14 @@ mod test {
         assert!(remote.has_data());
     }
 
-    //#[n_times(1000)]
+    #[n_times(50)]
     #[tokio::test]
     async fn race_get_manifest_and_offload_job() {
         // We want to race the offload-manifests job and the fetching of a manifest to the
         // persistence layers. We should end up in a consistent state, and fetches should
         // succeed, regardless of who wins.
 
-        const N: usize = 20;
+        const N: usize = 10;
         let runners: Vec<_> = (0..N).map(|i| Tag::runner(0, i as u32)).collect();
         let tests: Vec<_> = (0..N)
             .map(|i| WorkerTest::new(spec(i), INIT_RUN_NUMBER))
@@ -728,7 +728,7 @@ mod test {
             }
         };
 
-        if 1 % 2 == 0 {
+        if i % 2 == 0 {
             tokio::join!(fetch_task, offload_task);
         } else {
             tokio::join!(offload_task, fetch_task);

--- a/crates/abq_queue/src/persistence/offload.rs
+++ b/crates/abq_queue/src/persistence/offload.rs
@@ -1,0 +1,26 @@
+use std::time::Duration;
+
+#[derive(Clone, Copy)]
+enum OffloadConfigInner {
+    Never,
+    After(Duration),
+}
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct OffloadConfig(OffloadConfigInner);
+
+impl OffloadConfig {
+    pub const NEVER: Self = Self(OffloadConfigInner::Never);
+
+    pub fn new(offload_after: Duration) -> Self {
+        Self(OffloadConfigInner::After(offload_after))
+    }
+
+    pub fn should_offload(&self, elapsed_duration: Duration) -> bool {
+        match self.0 {
+            OffloadConfigInner::Never => false,
+            OffloadConfigInner::After(offload_after) => elapsed_duration >= offload_after,
+        }
+    }
+}

--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -28,6 +28,8 @@ pub use fake::error as fake_error;
 pub use fake::unreachable as fake_unreachable;
 #[cfg(test)]
 pub use fake::FakePersister;
+#[cfg(test)]
+pub use fake::OneWriteFakePersister;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PersistenceKind {

--- a/crates/abq_queue/src/persistence/remote/fake.rs
+++ b/crates/abq_queue/src/persistence/remote/fake.rs
@@ -1,10 +1,15 @@
 use std::path::Path;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
 use std::{future::Future, path::PathBuf};
 
+use abq_utils::atomic;
 use abq_utils::error::ErrorLocation;
 use abq_utils::here;
 use abq_utils::{error::OpaqueResult, net_protocol::workers::RunId};
 use async_trait::async_trait;
+use parking_lot::Mutex;
+use tokio::io::AsyncWriteExt;
 
 use super::{PersistenceKind, RemotePersistence};
 
@@ -27,10 +32,10 @@ pub async fn error(_x: PersistenceKind, _y: RunId, _z: PathBuf) -> OpaqueResult<
 impl<OnStoreFromDisk, OnStoreFromDiskF, OnLoad, OnLoadF> FakePersister<OnStoreFromDisk, OnLoad>
 where
     OnStoreFromDisk: Fn(PersistenceKind, RunId, PathBuf) -> OnStoreFromDiskF + Send + Sync,
-    OnStoreFromDiskF: Future<Output = OpaqueResult<()>> + Send + Sync,
+    OnStoreFromDiskF: Future<Output = OpaqueResult<()>> + Send,
 
     OnLoad: Fn(PersistenceKind, RunId, PathBuf) -> OnLoadF + Send + Sync,
-    OnLoadF: Future<Output = OpaqueResult<()>> + Send + Sync,
+    OnLoadF: Future<Output = OpaqueResult<()>> + Send,
 {
     pub fn new(on_store_from_disk: OnStoreFromDisk, on_load: OnLoad) -> Self {
         Self {
@@ -46,10 +51,10 @@ impl<OnStoreFromDisk, OnStoreFromDiskF, OnLoad, OnLoadF> RemotePersistence
 where
     OnStoreFromDisk:
         Fn(PersistenceKind, RunId, PathBuf) -> OnStoreFromDiskF + Send + Sync + Clone + 'static,
-    OnStoreFromDiskF: Future<Output = OpaqueResult<()>> + Send + Sync,
+    OnStoreFromDiskF: Future<Output = OpaqueResult<()>> + Send,
 
     OnLoad: Fn(PersistenceKind, RunId, PathBuf) -> OnLoadF + Send + Sync + Clone + 'static,
-    OnLoadF: Future<Output = OpaqueResult<()>> + Send + Sync,
+    OnLoadF: Future<Output = OpaqueResult<()>> + Send,
 {
     async fn store_from_disk(
         &self,
@@ -67,6 +72,66 @@ where
         into_local_path: &Path,
     ) -> OpaqueResult<()> {
         (self.on_load)(kind, run_id.clone(), into_local_path.to_owned()).await
+    }
+
+    fn boxed_clone(&self) -> Box<dyn RemotePersistence + Send + Sync> {
+        Box::new(self.clone())
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct OneWriteFakePersister {
+    stored: Arc<Mutex<Option<Vec<u8>>>>,
+    stored_to: Arc<AtomicUsize>,
+    loaded_from: Arc<AtomicUsize>,
+}
+
+impl OneWriteFakePersister {
+    pub fn stores(&self) -> usize {
+        self.stored_to.load(atomic::ORDERING)
+    }
+
+    pub fn loads(&self) -> usize {
+        self.loaded_from.load(atomic::ORDERING)
+    }
+
+    pub fn has_data(&self) -> bool {
+        self.stored.lock().is_some()
+    }
+}
+
+#[async_trait]
+impl RemotePersistence for OneWriteFakePersister {
+    async fn store_from_disk(
+        &self,
+        _kind: PersistenceKind,
+        _run_id: &RunId,
+        from_local_path: &Path,
+    ) -> OpaqueResult<()> {
+        self.stored_to.fetch_add(1, atomic::ORDERING);
+        let loaded = tokio::fs::read(from_local_path).await.unwrap();
+        let mut locked = self.stored.lock();
+        assert!(locked.replace(loaded).is_none());
+        Ok(())
+    }
+
+    async fn load_to_disk(
+        &self,
+        _kind: PersistenceKind,
+        _run_id: &RunId,
+        into_local_path: &Path,
+    ) -> OpaqueResult<()> {
+        self.loaded_from.fetch_add(1, atomic::ORDERING);
+        let data = self.stored.lock().clone().unwrap();
+        let mut file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(into_local_path)
+            .await
+            .unwrap();
+        file.write_all(&data).await.unwrap();
+        file.flush().await.unwrap();
+        Ok(())
     }
 
     fn boxed_clone(&self) -> Box<dyn RemotePersistence + Send + Sync> {


### PR DESCRIPTION
Adds a new `run_offload_job` to the local filesystem persistence of manifests that enables truncating manifest files when they've been determined to not have been accessed, and material in size, in a while.