### PR TITLE
Implement a job to cleanup result files to the remote

### DIFF
--- a/crates/abq_queue/src/persistence.rs
+++ b/crates/abq_queue/src/persistence.rs
@@ -4,4 +4,4 @@ pub mod results;
 pub mod remote;
 
 mod offload;
-pub use offload::OffloadConfig;
+pub use offload::{OffloadConfig, OffloadSummary};

--- a/crates/abq_queue/src/persistence/manifest/fs.rs
+++ b/crates/abq_queue/src/persistence/manifest/fs.rs
@@ -588,6 +588,12 @@ mod test {
             .await
             .unwrap();
 
+        let file_size = tokio::fs::metadata(fs.get_path(&run_id))
+            .await
+            .unwrap()
+            .len();
+        assert_eq!(file_size, 0);
+
         // Now when we load again, we should force a fetch of the remote.
         let tests = fs.get_partition_for_entity(&run_id, runner1).await.unwrap();
         assert_eq!(tests, vec![test1]);

--- a/crates/abq_queue/src/persistence/offload.rs
+++ b/crates/abq_queue/src/persistence/offload.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, SystemTime};
 use abq_utils::{
     error::{OpaqueResult, ResultLocation},
     here,
+    net_protocol::workers::RunId,
 };
 
 #[derive(Clone, Copy)]
@@ -47,4 +48,9 @@ impl OffloadConfig {
         };
         Ok(size > 0 && should_offload_time()?)
     }
+}
+
+#[must_use]
+pub struct OffloadSummary {
+    pub offloaded_run_ids: Vec<RunId>,
 }


### PR DESCRIPTION
Adds a new `run_offload_job` to the local filesystem persistence of results that enables truncating result files when they've been determined to not have been accessed, and material in size, in a while.

This completes the implementation needed to turn on periodic clean-up of on-disk manifests and test results. The next PR will implement the interface on the CLI.