### PR TITLE
Drop use of an LRU cache for results files

### DIFF
--- a/crates/abq_cli/src/instance.rs
+++ b/crates/abq_cli/src/instance.rs
@@ -254,11 +254,10 @@ async fn do_results_offload(results_persister: ResultsPersister, offload_config:
                 "Offloaded results to remote",
             )
         }
-        Err(err) => {
-            let LocatedError {
-                error,
-                location: Location { file, line, column },
-            } = &*err;
+        Err(LocatedError {
+            error,
+            location: Location { file, line, column },
+        }) => {
             tracing::error!(
                 file,
                 line,

--- a/crates/abq_queue/src/persistence/results.rs
+++ b/crates/abq_queue/src/persistence/results.rs
@@ -19,18 +19,18 @@ use abq_utils::{
 };
 use async_trait::async_trait;
 
-type ArcResult<T> = std::result::Result<T, Arc<LocatedError>>;
+type Result<T> = std::result::Result<T, LocatedError>;
 
 #[async_trait]
 pub trait PersistResults: Send + Sync {
     /// Dumps a summary line.
-    async fn dump(&self, run_id: &RunId, results: ResultsLine) -> ArcResult<()>;
+    async fn dump(&self, run_id: &RunId, results: ResultsLine) -> Result<()>;
 
     /// Dumps the persisted results to a remote, if any is configured.
-    async fn dump_to_remote(&self, run_id: &RunId) -> ArcResult<()>;
+    async fn dump_to_remote(&self, run_id: &RunId) -> Result<()>;
 
     /// Load a set of test results as [OpaqueLazyAssociatedTestResults].
-    async fn get_results(&self, run_id: &RunId) -> ArcResult<OpaqueLazyAssociatedTestResults>;
+    async fn get_results(&self, run_id: &RunId) -> Result<OpaqueLazyAssociatedTestResults>;
 
     fn boxed_clone(&self) -> Box<dyn PersistResults>;
 }
@@ -141,7 +141,7 @@ impl ResultsPersistedCell {
     pub async fn retrieve(
         &self,
         persistence: &SharedPersistResults,
-    ) -> Option<ArcResult<OpaqueLazyAssociatedTestResults>> {
+    ) -> Option<Result<OpaqueLazyAssociatedTestResults>> {
         if self.0.processing.load(atomic::ORDERING) != 0 {
             return None;
         }
@@ -157,7 +157,7 @@ pub struct PersistencePlan<'a> {
 }
 
 impl<'a> PersistencePlan<'a> {
-    pub async fn execute(self) -> ArcResult<()> {
+    pub async fn execute(self) -> Result<()> {
         let result = self
             .persist_results
             .dump(&self.cell.run_id, self.line)

--- a/crates/abq_queue/src/persistence/results/in_memory.rs
+++ b/crates/abq_queue/src/persistence/results/in_memory.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use serde_json::value::RawValue;
 use tokio::sync::RwLock;
 
-use super::{ArcResult, PersistResults, SharedPersistResults};
+use super::{PersistResults, Result, SharedPersistResults};
 
 #[derive(Default, Clone)]
 pub struct InMemoryPersistor {
@@ -27,7 +27,7 @@ impl InMemoryPersistor {
 
 #[async_trait]
 impl PersistResults for InMemoryPersistor {
-    async fn dump(&self, run_id: &RunId, results: ResultsLine) -> ArcResult<()> {
+    async fn dump(&self, run_id: &RunId, results: ResultsLine) -> Result<()> {
         let raw_line = serde_json::value::to_raw_value(&results).located(here!())?;
         let mut results = self.results.write().await;
         let entry = results.entry(run_id.clone()).or_default();
@@ -35,11 +35,11 @@ impl PersistResults for InMemoryPersistor {
         Ok(())
     }
 
-    async fn dump_to_remote(&self, _run_id: &RunId) -> ArcResult<()> {
+    async fn dump_to_remote(&self, _run_id: &RunId) -> Result<()> {
         Ok(())
     }
 
-    async fn get_results(&self, run_id: &RunId) -> ArcResult<OpaqueLazyAssociatedTestResults> {
+    async fn get_results(&self, run_id: &RunId) -> Result<OpaqueLazyAssociatedTestResults> {
         let results = self.results.read().await;
         let json_lines = results
             .get(run_id)

--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -2066,7 +2066,7 @@ impl QueueServer {
 
         match plan_result {
             Ok(plan) => {
-                let result = plan.execute().await.map_err(dearc_located);
+                let result = plan.execute().await;
                 result.or(opt_ack_error)
             }
             Err(_) => Err(cell_result.unwrap_err()),
@@ -2254,12 +2254,6 @@ impl QueueServer {
             }
         }
     }
-}
-
-/// Unwrap the Arc from a [LocatedError]. Needed sometimes when the return type expects a
-/// non-counted error; since a [LocatedError] is opaque, this simply converts it to a string.
-fn dearc_located(e: Arc<LocatedError>) -> LocatedError {
-    e.error.to_string().located(e.location)
 }
 
 fn log_deprecations(entity: Entity, run_id: RunId, deprecations: meta::DeprecationRecord) {
@@ -2505,7 +2499,7 @@ async fn run_summary_persistence_task(
         eligible_for_remote_dump,
     );
 
-    task.execute().await.map_err(dearc_located)
+    task.execute().await
 }
 
 #[instrument(level = "info", skip_all, fields(run_id=?run_id, entity=?entity))]


### PR DESCRIPTION
Using an LRU cache of file descriptors for results files could induce the following race:

- A file P is opened, put in a mutex M, and placed into the cache. We hand to one thread 1 the mutex M.
- Thread 1 takes exclusive access of M.
- M is evicted from the cache. Thread 1 still has exclusive access to M.
- Thread 2 requests access to P from the cache. P is opened **in a new file descriptor** and placed in a new mutex O.
- Thread 2 takes exclusive access of O.
- Thread 1 and Thread 2 can now have unsynchronized writes to their file descriptors, which are different but point to the same filesystem inode.

This was a race to unlikely occur in practice, but it appears that it can in fact occur.

The solution presented in this patch is to not maintain an LRU cache, but a cache of file descriptors that never evicts locked file descriptors. Once the results file for a run ID is entered into the cache, the entry will never be removed. An entry can be in two states:

- Open: the file descriptor is open, and this is the unique file descriptor an ABQ queue has to a results file.
- Offloaded: the file was offloaded to a remote and no file descriptor is available until it is loaded from the remote.

This implementation trades off speed of access for memory usage. We should expect that memory usage will grow steadily, and at a small, consistent rate similar to that of the main queue state (that is, linear to the number of run IDs on a queue). Since the cache entry is a string and file descriptor + lock, I don't expect this to constitute a serious source of memory leaks.

Alternative implementations to be considered:

- Use `flock` instead. This is likely too slow for our use case, since writes are frequent to result files when active. Also, this will not work on NFS.
- Perform all writes on a single thread and use channels to communicate messages. This could backup reads of test results significantly if there are many writes (including to other result files) ahead of it.
- Use a database (e.g. SQLite) instead