### PR TITLE
Load run states from remote

### DIFF
--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -3083,7 +3083,10 @@ fn custom_remote_persistence() {
         const kind = process.argv[3];
         const runId = process.argv[4];
         const readFrom = process.argv[5];
-        const writeTo = `${{dir}}/${{action}}-${{kind}}-${{runId}}`
+        const writeTo = `${{dir}}/${{action}}-${{kind}}-${{runId}}`;
+
+        // If we're loading a run state, fail - each run should be fresh.
+        if (kind === 'run_state' && action === 'load') process.exit(1);
 
         const data = fs.readFileSync(readFrom, `utf8`);
         fs.writeFileSync(writeTo, data);

--- a/crates/abq_queue/src/persistence/manifest.rs
+++ b/crates/abq_queue/src/persistence/manifest.rs
@@ -120,6 +120,10 @@ impl ManifestPersistedCell {
     pub fn is_persisted(&self) -> bool {
         self.0.load(atomic::ORDERING)
     }
+
+    pub fn new_already_persisted() -> Self {
+        Self(Arc::new(AtomicBool::new(true)))
+    }
 }
 
 #[derive(Debug)]

--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -136,4 +136,8 @@ impl RemotePersister {
     ) -> OpaqueResult<()> {
         self.0.load_to_disk(kind, run_id, into_local_path).await
     }
+
+    pub async fn has_run_id(&self, run_id: &RunId) -> OpaqueResult<bool> {
+        self.0.has_run_id(run_id).await
+    }
 }

--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -137,7 +137,15 @@ impl RemotePersister {
         self.0.load_to_disk(kind, run_id, into_local_path).await
     }
 
-    pub async fn has_run_id(&self, run_id: &RunId) -> OpaqueResult<bool> {
-        self.0.has_run_id(run_id).await
+    pub async fn store_run_state(
+        &self,
+        run_id: &RunId,
+        state: SerializableRunState,
+    ) -> OpaqueResult<()> {
+        self.0.store_run_state(run_id, state).await
+    }
+
+    pub async fn try_load_run_state(&self, run_id: &RunId) -> OpaqueResult<LoadedRunState> {
+        self.0.try_load_run_state(run_id).await
     }
 }

--- a/crates/abq_queue/src/persistence/remote.rs
+++ b/crates/abq_queue/src/persistence/remote.rs
@@ -98,6 +98,9 @@ pub trait RemotePersistence {
     fn boxed_clone(&self) -> Box<dyn RemotePersistence + Send + Sync>;
 }
 
+/// A shared wrapper around [RemotePersister].
+///
+/// Clones are cheap, as they are atomically reference counted.
 #[derive(Clone)]
 #[repr(transparent)]
 pub struct RemotePersister(Arc<Box<dyn RemotePersistence + Send + Sync>>);

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -14,7 +14,7 @@ use abq_queue::{
     persistence::{
         self,
         manifest::ManifestView,
-        remote::{LoadedRunState, PersistenceKind, RemotePersistence},
+        remote::{LoadedRunState, PersistenceKind, RemotePersistence, RemotePersister},
         SerializableRunState,
     },
     queue::{Abq, QueueConfig},

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -92,7 +92,8 @@ struct Server {
 
 impl Default for Server {
     fn default() -> Self {
-        let remote = InMemoryRemote::default();
+        let raw_remote = InMemoryRemote::default();
+        let remote: RemotePersister = raw_remote.clone().into();
 
         let manifests_path = tempfile::tempdir().unwrap();
         let persist_manifest = persistence::manifest::FilesystemPersistor::new_shared(
@@ -107,7 +108,7 @@ impl Default for Server {
             remote.clone(),
         );
 
-        let config = QueueConfig::new(persist_manifest, persist_results);
+        let config = QueueConfig::new(persist_manifest, persist_results, remote);
         let deps = QueueExtDeps {
             _manifests_path: manifests_path,
             _results_path: results_path,
@@ -115,7 +116,7 @@ impl Default for Server {
         Self {
             config,
             deps,
-            remote,
+            remote: raw_remote,
         }
     }
 }

--- a/crates/abq_workers/src/assigned_run.rs
+++ b/crates/abq_workers/src/assigned_run.rs
@@ -19,6 +19,7 @@ pub enum AssignedRunStatus {
     AlreadyDone {
         exit_code: abq_utils::exit::ExitCode,
     },
+    FatalError(String),
 }
 
 impl AssignedRunStatus {

--- a/crates/abq_workers/src/assigned_run.rs
+++ b/crates/abq_workers/src/assigned_run.rs
@@ -11,6 +11,7 @@ pub enum AssignedRun {
     Retry,
 }
 
+#[must_use]
 #[derive(Debug, PartialEq, Eq)]
 pub enum AssignedRunStatus {
     RunUnknown,


### PR DESCRIPTION
This patch supports a queue instance loading in a previous run's state from storage in a remote persistence location. This is not yet exercised; the next PR will actually store run state when a manifest is completed.

This branch is active when a run first starts - the first connector will opportunistically check if a remote run state exists, and load from that if it does, or fallback to a new run otherwise.

The implementation takes as a precondition that a run is only ever routed to one active ABQ queue. This will be documented in the public API when released.