### PR TITLE
Add a model for persisting run state when a run completes

### DIFF
--- a/crates/abq_queue/src/persistence.rs
+++ b/crates/abq_queue/src/persistence.rs
@@ -3,5 +3,7 @@ pub mod results;
 
 pub mod remote;
 
+pub mod run_state;
+
 mod offload;
 pub use offload::{OffloadConfig, OffloadSummary};

--- a/crates/abq_queue/src/persistence.rs
+++ b/crates/abq_queue/src/persistence.rs
@@ -7,3 +7,4 @@ pub mod run_state;
 
 mod offload;
 pub use offload::{OffloadConfig, OffloadSummary};
+pub use run_state::SerializableRunState;

--- a/crates/abq_queue/src/persistence/remote/custom.rs
+++ b/crates/abq_queue/src/persistence/remote/custom.rs
@@ -162,7 +162,7 @@ impl RemotePersistence for CustomPersister {
             return Ok(LoadedRunState::NotFound);
         }
 
-        let result = tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || {
             let mut temp_file = temp_file.reopen().located(here!())?;
             let mut bytes = vec![];
             temp_file.read_to_end(&mut bytes).located(here!())?;
@@ -176,9 +176,7 @@ impl RemotePersistence for CustomPersister {
             }
         })
         .await
-        .located(here!())?;
-
-        result
+        .located(here!())?
     }
 
     fn boxed_clone(&self) -> Box<dyn RemotePersistence + Send + Sync> {
@@ -386,7 +384,7 @@ mod test {
 
     #[tokio::test]
     async fn load_run_state_incompatible_versions() {
-        let fi = write_js(&indoc!(
+        let fi = write_js(indoc!(
             r#"
             if (process.argv[2] !== "load") process.exit(1);
             if (process.argv[3] !== "run_state") process.exit(1);

--- a/crates/abq_queue/src/persistence/remote/custom.rs
+++ b/crates/abq_queue/src/persistence/remote/custom.rs
@@ -1,4 +1,7 @@
-use std::path::Path;
+use std::{
+    io::{Read, Write},
+    path::Path,
+};
 
 use abq_utils::{
     error::{OpaqueResult, ResultLocation},
@@ -7,7 +10,9 @@ use abq_utils::{
 };
 use async_trait::async_trait;
 
-use super::{PersistenceKind, RemotePersistence};
+use crate::persistence::run_state::{self, SerializableRunState};
+
+use super::{LoadedRunState, PersistenceKind, RemotePersistence};
 
 /// A custom [remote file persistor][RemotePersistence], whose implementation is defined by an
 /// external process.
@@ -16,17 +21,12 @@ use super::{PersistenceKind, RemotePersistence};
 /// in the PATH, and is called in the following form:
 ///
 /// ```bash
-/// <command> <..args> <action=load|store|exists> <kind=manifest|results> <run_id> <path?>
+/// <command> <..args> <action=load|store> <kind=manifest|results|run_state> <run_id> <path?>
 /// ```
 ///
 /// The behavior for each action should be as follows:
-/// - `exists`: the process must print "true" to stdout if the data for a run_id exists,
-///   or "false" otherwise.
-///   Output will be trimmed, but nothing else should be written to stdout.
 /// - `load`: the process must load the remote data into `path`.
 /// - `store`: the process must store the remote data into `path`.
-///
-/// `path` is only present if the action is `load` or `store`.
 ///
 /// The process must exit with a zero exit code on success, and a non-zero exit code on failure.
 /// If the process exits with a non-zero exit code, the error message will be the contents of the
@@ -41,7 +41,6 @@ pub struct CustomPersister {
 enum Action {
     Load,
     Store,
-    Exists,
 }
 
 impl CustomPersister {
@@ -61,14 +60,13 @@ impl CustomPersister {
         action: Action,
         kind: PersistenceKind,
         run_id: &RunId,
-        path: Option<&Path>,
-    ) -> OpaqueResult<Vec<u8>> {
+        path: &Path,
+    ) -> OpaqueResult<()> {
         tracing::info!(?path, ?action, "calling with");
 
         let action = match action {
             Action::Load => "load",
             Action::Store => "store",
-            Action::Exists => "exists",
         };
 
         let mut cmd = tokio::process::Command::new(&self.command);
@@ -76,13 +74,11 @@ impl CustomPersister {
         cmd.arg(action);
         cmd.arg(kind.kind_str());
         cmd.arg(run_id.to_string());
-        if let Some(path) = path {
-            cmd.arg(path);
-        }
+        cmd.arg(path);
 
         let std::process::Output {
             status,
-            stdout,
+            stdout: _,
             stderr,
         } = cmd.output().await.located(here!())?;
 
@@ -94,7 +90,7 @@ impl CustomPersister {
             .located(here!());
         }
 
-        Ok(stdout)
+        Ok(())
     }
 }
 
@@ -106,7 +102,7 @@ impl RemotePersistence for CustomPersister {
         run_id: &RunId,
         path: &Path,
     ) -> OpaqueResult<()> {
-        self.call(Action::Load, kind, run_id, Some(path)).await?;
+        self.call(Action::Load, kind, run_id, path).await?;
         Ok(())
     }
 
@@ -116,25 +112,73 @@ impl RemotePersistence for CustomPersister {
         run_id: &RunId,
         path: &Path,
     ) -> OpaqueResult<()> {
-        self.call(Action::Store, kind, run_id, Some(path)).await?;
+        self.call(Action::Store, kind, run_id, path).await?;
         Ok(())
     }
 
-    async fn has_run_id(&self, run_id: &RunId) -> OpaqueResult<bool> {
-        let output = self
-            .call(Action::Exists, PersistenceKind::Manifest, run_id, None)
-            .await?;
-        let output = String::from_utf8_lossy(&output);
-        let output = output.trim();
-        match output {
-            "true" => Ok(true),
-            "false" => Ok(false),
-            _ => Err(format!(
-                "custom persister returned invalid output: {}",
-                output
-            ))
-            .located(here!()),
+    async fn store_run_state(
+        &self,
+        run_id: &RunId,
+        run_state: SerializableRunState,
+    ) -> OpaqueResult<()> {
+        let write_to_temp_task = move || {
+            let mut temp_file = tempfile::NamedTempFile::new().located(here!())?;
+            run_state.serialize_to(&mut temp_file).located(here!())?;
+            temp_file.flush().located(here!())?;
+            Ok(temp_file)
+        };
+
+        let temp_file = tokio::task::spawn_blocking(write_to_temp_task)
+            .await
+            .located(here!())??;
+
+        self.call(
+            Action::Store,
+            PersistenceKind::RunState,
+            run_id,
+            temp_file.path(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn try_load_run_state(&self, run_id: &RunId) -> OpaqueResult<LoadedRunState> {
+        let temp_file =
+            tokio::task::spawn_blocking(move || tempfile::NamedTempFile::new().located(here!()))
+                .await
+                .located(here!())??;
+
+        let load_result = self
+            .call(
+                Action::Load,
+                PersistenceKind::RunState,
+                run_id,
+                temp_file.path(),
+            )
+            .await;
+
+        if load_result.is_err() {
+            return Ok(LoadedRunState::NotFound);
         }
+
+        let result = tokio::task::spawn_blocking(move || {
+            let mut temp_file = temp_file.reopen().located(here!())?;
+            let mut bytes = vec![];
+            temp_file.read_to_end(&mut bytes).located(here!())?;
+
+            match SerializableRunState::deserialize(&bytes) {
+                Ok(run_state) => Ok(LoadedRunState::Found(run_state.into_run_state())),
+                Err(run_state::ParseError::IncompatibleSchemaVersion { found, expected }) => {
+                    Ok(LoadedRunState::IncompatibleSchemaVersion { found, expected })
+                }
+                Err(e) => Err(e).located(here!()),
+            }
+        })
+        .await
+        .located(here!())?;
+
+        result
     }
 
     fn boxed_clone(&self) -> Box<dyn RemotePersistence + Send + Sync> {
@@ -147,10 +191,13 @@ mod test {
     use std::{io::Write, path::Path};
 
     use abq_utils::net_protocol::workers::RunId;
-    use indoc::indoc;
+    use indoc::{formatdoc, indoc};
     use tempfile::NamedTempFile;
 
-    use crate::persistence::remote::RemotePersistence;
+    use crate::persistence::{
+        remote::{LoadedRunState, RemotePersistence},
+        run_state::{RunState, SerializableRunState},
+    };
 
     fn write_js(content: &str) -> NamedTempFile {
         let mut fi = NamedTempFile::new().unwrap();
@@ -251,70 +298,28 @@ mod test {
     }
 
     #[tokio::test]
-    async fn exists_yes() {
+    async fn store_run_state_okay() {
         let fi = write_js(indoc!(
             r#"
-            if (process.argv[2] !== "exists") process.exit(1);
-            if (process.argv[3] !== "manifest") process.exit(1);
+            if (process.argv[2] !== "store") process.exit(1);
+            if (process.argv[3] !== "run_state") process.exit(1);
             if (process.argv[4] !== "run-id") process.exit(1);
-            console.log("true")
             "#,
         ));
 
         let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
 
-        let exists = persister
-            .has_run_id(&RunId("run-id".to_string()))
+        persister
+            .store_run_state(
+                &RunId("run-id".to_string()),
+                SerializableRunState::new(RunState::fake()),
+            )
             .await
             .unwrap();
-
-        assert!(exists);
     }
 
     #[tokio::test]
-    async fn exists_no() {
-        let fi = write_js(indoc!(
-            r#"
-            if (process.argv[2] !== "exists") process.exit(1);
-            if (process.argv[3] !== "manifest") process.exit(1);
-            if (process.argv[4] !== "run-id") process.exit(1);
-            console.log("false")
-            "#,
-        ));
-
-        let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
-
-        let exists = persister
-            .has_run_id(&RunId("run-id".to_string()))
-            .await
-            .unwrap();
-
-        assert!(!exists);
-    }
-
-    #[tokio::test]
-    async fn exists_bad_message() {
-        let fi = write_js(indoc!(
-            r#"
-            if (process.argv[2] !== "exists") process.exit(1);
-            if (process.argv[3] !== "manifest") process.exit(1);
-            if (process.argv[4] !== "run-id") process.exit(1);
-            console.log("maybe")
-            "#,
-        ));
-
-        let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
-
-        let exists_err = persister
-            .has_run_id(&RunId("run-id".to_string()))
-            .await
-            .unwrap_err();
-
-        assert!(exists_err.to_string().contains("invalid output: maybe"));
-    }
-
-    #[tokio::test]
-    async fn exists_error() {
+    async fn store_run_state_error() {
         let fi = write_js(indoc!(
             r#"
             console.error("I have failed");
@@ -325,10 +330,106 @@ mod test {
         let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
 
         let err = persister
-            .has_run_id(&RunId("run-id".to_string()))
+            .store_run_state(
+                &RunId("run-id".to_string()),
+                SerializableRunState::new(RunState::fake()),
+            )
             .await
             .unwrap_err();
 
         assert!(err.to_string().contains("I have failed"));
+    }
+
+    #[tokio::test]
+    async fn load_run_state_okay() {
+        let run_state = SerializableRunState::new(RunState::fake());
+
+        let fi = write_js(&formatdoc!(
+            r#"
+            if (process.argv[2] !== "load") process.exit(1);
+            if (process.argv[3] !== "run_state") process.exit(1);
+            if (process.argv[4] !== "run-id") process.exit(1);
+            const target = process.argv[5];
+            require('fs').writeFileSync(target, `{json}`);
+            "#,
+            json = String::from_utf8_lossy(&run_state.serialize().unwrap()),
+        ));
+
+        let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
+
+        let loaded = persister
+            .try_load_run_state(&RunId("run-id".to_string()))
+            .await
+            .unwrap();
+
+        assert_eq!(loaded, LoadedRunState::Found(run_state.into_run_state()));
+    }
+
+    #[tokio::test]
+    async fn load_run_state_not_found() {
+        let fi = write_js(indoc!(
+            r#"
+            console.error("I have not found it");
+            process.exit(1);
+            "#,
+        ));
+
+        let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
+
+        let loaded = persister
+            .try_load_run_state(&RunId("run-id".to_string()))
+            .await
+            .unwrap();
+
+        assert_eq!(loaded, LoadedRunState::NotFound);
+    }
+
+    #[tokio::test]
+    async fn load_run_state_incompatible_versions() {
+        let fi = write_js(&indoc!(
+            r#"
+            if (process.argv[2] !== "load") process.exit(1);
+            if (process.argv[3] !== "run_state") process.exit(1);
+            if (process.argv[4] !== "run-id") process.exit(1);
+            const target = process.argv[5];
+            require('fs').writeFileSync(target, `{"schema_version": 999}`);
+            "#,
+        ));
+
+        let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
+
+        let loaded = persister
+            .try_load_run_state(&RunId("run-id".to_string()))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            loaded,
+            LoadedRunState::IncompatibleSchemaVersion {
+                found: 999,
+                expected: _
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn load_run_state_corrupted() {
+        let fi = write_js(indoc!(
+            r#"
+            if (process.argv[2] !== "load") process.exit(1);
+            if (process.argv[3] !== "run_state") process.exit(1);
+            if (process.argv[4] !== "run-id") process.exit(1);
+            const target = process.argv[5];
+            require('fs').writeFileSync(target, "this is not json");
+            "#,
+        ));
+
+        let persister = super::CustomPersister::new("node", vec![fi.path().display().to_string()]);
+
+        let loaded = persister
+            .try_load_run_state(&RunId("run-id".to_string()))
+            .await;
+
+        assert!(loaded.is_err());
     }
 }

--- a/crates/abq_queue/src/persistence/remote/fake.rs
+++ b/crates/abq_queue/src/persistence/remote/fake.rs
@@ -11,7 +11,9 @@ use async_trait::async_trait;
 use parking_lot::Mutex;
 use tokio::io::AsyncWriteExt;
 
-use super::{PersistenceKind, RemotePersistence};
+use crate::persistence::run_state::SerializableRunState;
+
+use super::{LoadedRunState, PersistenceKind, RemotePersistence};
 
 #[derive(Clone)]
 pub struct FakePersister<OnStoreFromDisk, OnLoad> {
@@ -74,8 +76,16 @@ where
         (self.on_load)(kind, run_id.clone(), into_local_path.to_owned()).await
     }
 
-    async fn has_run_id(&self, _run_id: &RunId) -> OpaqueResult<bool> {
-        unimplemented!("FakePersister does not support checking for run_id existence.");
+    async fn store_run_state(
+        &self,
+        _run_id: &RunId,
+        _run_state: SerializableRunState,
+    ) -> OpaqueResult<()> {
+        unimplemented!("FakePersister does not support storing run state.")
+    }
+
+    async fn try_load_run_state(&self, _run_id: &RunId) -> OpaqueResult<LoadedRunState> {
+        unimplemented!("FakePersister does not support loading run state.")
     }
 
     fn boxed_clone(&self) -> Box<dyn RemotePersistence + Send + Sync> {
@@ -145,8 +155,16 @@ impl RemotePersistence for OneWriteFakePersister {
         Ok(())
     }
 
-    async fn has_run_id(&self, _run_id: &RunId) -> OpaqueResult<bool> {
-        Ok(self.has_data())
+    async fn store_run_state(
+        &self,
+        _run_id: &RunId,
+        _run_state: SerializableRunState,
+    ) -> OpaqueResult<()> {
+        unimplemented!("FakePersister does not support storing run state.");
+    }
+
+    async fn try_load_run_state(&self, _run_id: &RunId) -> OpaqueResult<LoadedRunState> {
+        unimplemented!("FakePersister does not support loading run state.");
     }
 
     fn boxed_clone(&self) -> Box<dyn RemotePersistence + Send + Sync> {

--- a/crates/abq_queue/src/persistence/remote/noop.rs
+++ b/crates/abq_queue/src/persistence/remote/noop.rs
@@ -7,7 +7,9 @@ use abq_utils::{
 };
 use async_trait::async_trait;
 
-use super::{PersistenceKind, RemotePersistence};
+use crate::persistence::run_state::SerializableRunState;
+
+use super::{LoadedRunState, PersistenceKind, RemotePersistence};
 
 #[derive(Clone, Default)]
 pub struct NoopPersister;
@@ -38,8 +40,16 @@ impl RemotePersistence for NoopPersister {
         Err("NoopPersister does not support loading.".located(here!()))
     }
 
-    async fn has_run_id(&self, _run_id: &RunId) -> OpaqueResult<bool> {
-        unimplemented!("NoopPersister does not support checking for run_id existence.")
+    async fn store_run_state(
+        &self,
+        _run_id: &RunId,
+        _state: SerializableRunState,
+    ) -> OpaqueResult<()> {
+        Ok(())
+    }
+
+    async fn try_load_run_state(&self, _run_id: &RunId) -> OpaqueResult<LoadedRunState> {
+        Ok(LoadedRunState::NotFound)
     }
 
     fn boxed_clone(&self) -> Box<dyn RemotePersistence + Send + Sync> {

--- a/crates/abq_queue/src/persistence/run_state.rs
+++ b/crates/abq_queue/src/persistence/run_state.rs
@@ -1,0 +1,156 @@
+//! Representation of run state that can be persisted to a remote and loaded from a remote.
+//! See [crate::queue::RunState::InitialManifestDone].
+
+use abq_utils::{
+    exit::ExitCode,
+    net_protocol::{entity::Entity, runners::MetadataMap},
+};
+use serde_derive::{Deserialize, Serialize};
+use thiserror::Error;
+
+const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// The version of the schema used by this serialized state.
+/// Incompatible schemas cannot be read.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+struct SchemaVersion {
+    schema_version: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct RunState {
+    pub new_worker_exit_code: ExitCode,
+    pub init_metadata: MetadataMap,
+    pub seen_workers: Vec<Entity>,
+}
+
+/// Internal representation of a run state, that can be serialized to and deserialized from a
+/// remote.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct SerializedRunState {
+    #[serde(flatten)]
+    schema_version: SchemaVersion,
+
+    #[serde(flatten)]
+    run_state: RunState,
+}
+
+#[derive(Debug, Error)]
+pub enum ParseError {
+    #[error("expected schema version {expected}, found {found}")]
+    IncompatibleSchemaVersion { found: u32, expected: u32 },
+    #[error("{0}")]
+    Other(#[from] serde_json::Error),
+}
+
+impl SerializedRunState {
+    pub fn new(run_state: RunState) -> Self {
+        Self {
+            schema_version: SchemaVersion {
+                schema_version: CURRENT_SCHEMA_VERSION,
+            },
+            run_state,
+        }
+    }
+
+    pub fn into_run_state(self) -> RunState {
+        self.run_state
+    }
+
+    pub fn deserialize(bytes: &[u8]) -> Result<Self, ParseError> {
+        let err = match serde_json::from_slice(bytes) {
+            Ok(run_state) => return Ok(run_state),
+            Err(err) => err,
+        };
+
+        // For a better error message, try to deserialize the schema version separately.
+        let schema_version: SchemaVersion = serde_json::from_slice(bytes)?;
+        if schema_version.schema_version != CURRENT_SCHEMA_VERSION {
+            Err(ParseError::IncompatibleSchemaVersion {
+                found: schema_version.schema_version,
+                expected: CURRENT_SCHEMA_VERSION,
+            })
+        } else {
+            Err(err.into())
+        }
+    }
+
+    pub fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_serialize_deserialize() {
+        let run_state = RunState {
+            new_worker_exit_code: ExitCode::SUCCESS,
+            init_metadata: MetadataMap::new(),
+            seen_workers: vec![],
+        };
+        let serialized = SerializedRunState::new(run_state.clone());
+        let serialized_bytes = serialized.serialize().unwrap();
+        let deserialized = SerializedRunState::deserialize(&serialized_bytes).unwrap();
+        assert_eq!(deserialized.into_run_state(), run_state);
+
+        insta::assert_json_snapshot!(serialized, @r###"
+        {
+          "schema_version": 1,
+          "new_worker_exit_code": 0,
+          "init_metadata": {},
+          "seen_workers": []
+        }
+        "###);
+    }
+
+    #[test]
+    fn test_deserialize_incompatible_schema() {
+        let serialized = r###"
+        {
+            "schema_version": 16,
+            "worker_foobar": {}
+        }
+        "###;
+        let err = SerializedRunState::deserialize(&serialized.as_bytes()).unwrap_err();
+
+        assert!(matches!(
+            err,
+            ParseError::IncompatibleSchemaVersion {
+                expected: 1,
+                found: 16
+            }
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_compatible_schema_but_different_version() {
+        let run_state = RunState {
+            new_worker_exit_code: ExitCode::SUCCESS,
+            init_metadata: MetadataMap::new(),
+            seen_workers: vec![],
+        };
+        let serialized = SerializedRunState {
+            schema_version: SchemaVersion {
+                schema_version: CURRENT_SCHEMA_VERSION + 10,
+            },
+            run_state: run_state.clone(),
+        };
+        let serialized_bytes = serialized.serialize().unwrap();
+        let deserialized = SerializedRunState::deserialize(&serialized_bytes).unwrap();
+        assert_eq!(deserialized.into_run_state(), run_state);
+    }
+
+    #[test]
+    fn test_deserialize_bad_json() {
+        let serialized = r###"
+        {
+            "schema_version": 16,
+        "###;
+        let err = SerializedRunState::deserialize(&serialized.as_bytes()).unwrap_err();
+
+        assert!(matches!(err, ParseError::Other(..)));
+    }
+}

--- a/crates/abq_queue/src/persistence/run_state.rs
+++ b/crates/abq_queue/src/persistence/run_state.rs
@@ -137,7 +137,7 @@ mod test {
             "worker_foobar": {}
         }
         "###;
-        let err = SerializableRunState::deserialize(&serialized.as_bytes()).unwrap_err();
+        let err = SerializableRunState::deserialize(serialized.as_bytes()).unwrap_err();
 
         assert!(matches!(
             err,
@@ -172,7 +172,7 @@ mod test {
         {
             "schema_version": 16,
         "###;
-        let err = SerializableRunState::deserialize(&serialized.as_bytes()).unwrap_err();
+        let err = SerializableRunState::deserialize(serialized.as_bytes()).unwrap_err();
 
         assert!(matches!(err, ParseError::Other(..)));
     }


### PR DESCRIPTION
ABQ's internal representation of runs has a few details that are not reflected in either the persisted manifest or results files. The three big pieces we cannot easily recover are:

- The exit code that should be shown for new worker/runners
- What worker/runners were seen the first time a manifest was executed
- The metadata needed to initialize each worker/runner

The worker/runner pairs can actually be recovered from the manifest, but since the other items here are needed as well, all three are put into a new "RunState" data model that will be serialized to a remote location when the initial manifest for a run completes handing out.

The RunState has a schema_version that we can use to future-proof the attempted parsing of schemas that are incompatible with certain versions of ABQ.

This will be used to support sharing ABQ runs between queue instances.