### PR TITLE
Don't send results to queue when using PAT

### DIFF
--- a/.github/workflows/test_and_package_development.yml
+++ b/.github/workflows/test_and_package_development.yml
@@ -118,7 +118,7 @@ jobs:
         timeout-minutes: 4
         if: github.run_attempt == 1
         run: |
-          cargo test --profile=release-unstable --all-features --target="$RUST_TARGET"
+          cargo test --profile=release-unstable --all-features --target="$RUST_TARGET" -- --nocapture
         env:
           CI: false
 

--- a/.github/workflows/test_and_package_development.yml
+++ b/.github/workflows/test_and_package_development.yml
@@ -118,7 +118,7 @@ jobs:
         timeout-minutes: 4
         if: github.run_attempt == 1
         run: |
-          cargo test --profile=release-unstable --all-features --target="$RUST_TARGET" -- --nocapture
+          cargo test --profile=release-unstable --all-features --target="$RUST_TARGET"
         env:
           CI: false
 

--- a/.github/workflows/test_and_package_development.yml
+++ b/.github/workflows/test_and_package_development.yml
@@ -118,7 +118,7 @@ jobs:
         timeout-minutes: 4
         if: github.run_attempt == 1
         run: |
-          cargo test --profile=release-unstable --all-features --target="$RUST_TARGET" -- --nocapture
+          cargo test --profile=release-unstable --all-features --target="$RUST_TARGET" -- --nocapture --test-threads=1
         env:
           CI: false
 

--- a/.github/workflows/test_and_package_development.yml
+++ b/.github/workflows/test_and_package_development.yml
@@ -118,7 +118,7 @@ jobs:
         timeout-minutes: 4
         if: github.run_attempt == 1
         run: |
-          cargo test --profile=release-unstable --all-features --target="$RUST_TARGET" -- --nocapture --test-threads=1
+          cargo test --profile=release-unstable --all-features --target="$RUST_TARGET" -- --nocapture
         env:
           CI: false
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "atty",
  "clap",
  "cron",
+ "etcetera",
  "fnv",
  "futures",
  "indicatif",
@@ -48,6 +49,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-cron-scheduler",
+ "toml 0.7.4",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1213,6 +1215,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2171,7 +2193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
- "toml",
+ "toml 0.5.9",
 ]
 
 [[package]]
@@ -2541,6 +2563,15 @@ checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+dependencies = [
  "serde",
 ]
 
@@ -2920,6 +2951,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d964908cec0d030b812013af25a0e57fddfadb1e066ecc6681d86253129d4f"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3432,6 +3497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3574,6 +3648,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "mockito",
  "reqwest",
  "serde",
+ "serde_derive",
  "thiserror",
  "tracing",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "indicatif",
  "indoc",
  "insta",
+ "mockito",
  "nix",
  "ntest",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "thiserror",
+ "tokio",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ serde = "1.0.158"
 serde_derive = "1.0.158"
 serde_json = { version = "1.0.94", features = ["raw_value"] }
 
+etcetera = "0.8.0"
+toml = "0.7.4"
 rustls = "0.20.8"
 rustls-pemfile = "1.0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ derive_more = "0.99.17"
 
 insta = { version = "1.29.0", features = ["json", "redactions"] }
 paste = "1.0.12"
+mockito = "1.0.1"
 
 tempfile = "3.4.0"
 tracing-test = { version = "0.2.4", features = ["no-env-filter"] }

--- a/crates/abq_cli/Cargo.toml
+++ b/crates/abq_cli/Cargo.toml
@@ -24,6 +24,8 @@ serde.workspace = true
 serde_json.workspace = true
 serde_derive.workspace = true
 thiserror.workspace = true
+etcetera.workspace = true
+toml.workspace = true
 
 clap.workspace = true
 num_cpus.workspace = true

--- a/crates/abq_cli/Cargo.toml
+++ b/crates/abq_cli/Cargo.toml
@@ -64,6 +64,7 @@ ntest.workspace = true
 tempfile.workspace = true
 rand.workspace = true
 regex.workspace = true
+mockito.workspace = true
 
 [features]
 test-abq-jest = []

--- a/crates/abq_cli/src/abq_config.rs
+++ b/crates/abq_cli/src/abq_config.rs
@@ -1,16 +1,16 @@
 use anyhow::anyhow;
-use std::{fs, path::PathBuf};
+use std::{fs, path::{PathBuf, Path}};
 
 use abq_hosted::AccessToken;
 use etcetera::{app_strategy, AppStrategy, AppStrategyArgs};
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub struct AbqConfig {
     pub rwx_access_token: AccessToken,
 }
 
-fn abq_config_filepath() -> anyhow::Result<PathBuf> {
+pub fn abq_config_filepath() -> anyhow::Result<PathBuf> {
     let strategy = app_strategy::Unix::new(AppStrategyArgs {
         top_level_domain: "org".to_string(),
         author: "rwx".to_string(),
@@ -20,8 +20,8 @@ fn abq_config_filepath() -> anyhow::Result<PathBuf> {
     Ok(config_dir.join("config.toml"))
 }
 
-pub fn write_abq_config(config: AbqConfig) -> anyhow::Result<PathBuf> {
-    let abq_config_filepath = abq_config_filepath()?;
+pub fn write_abq_config(config: AbqConfig, config_path: anyhow::Result<PathBuf>) -> anyhow::Result<PathBuf> {
+    let abq_config_filepath = config_path?;
     let config_dir = abq_config_filepath
         .parent()
         .ok_or_else(|| anyhow!("abq config file must have parent dir"))?;
@@ -31,8 +31,37 @@ pub fn write_abq_config(config: AbqConfig) -> anyhow::Result<PathBuf> {
     Ok(abq_config_filepath)
 }
 
-pub fn read_abq_config() -> anyhow::Result<AbqConfig> {
-    let toml_str = fs::read_to_string(abq_config_filepath()?)?;
+pub fn read_abq_config(path: anyhow::Result<PathBuf>) -> anyhow::Result<AbqConfig> {
+    let toml_str = fs::read_to_string(path?)?;
     let config = toml::from_str(&toml_str)?;
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_abq_config_operations() {
+        let access_token = AccessToken::from_str("testy_mctesterson").unwrap();
+        // Create a temporary directory to store the config file
+        let tmp_config_file = NamedTempFile::new().expect("Failed to create temporary file");
+
+        // Set up the test configuration
+        let config = AbqConfig {
+            rwx_access_token: access_token,
+        };
+
+        // Write the config file
+        let config_path = write_abq_config(config, Ok(tmp_config_file.path().to_path_buf()));
+
+        // Read the config file
+        let read_config = read_abq_config(config_path);
+        assert!(read_config.is_ok());
+
+        assert_eq!(read_config.unwrap().rwx_access_token.to_string(), "testy_mctesterson");
+    }
 }

--- a/crates/abq_cli/src/abq_config.rs
+++ b/crates/abq_cli/src/abq_config.rs
@@ -1,0 +1,36 @@
+use std::{path::{PathBuf}, fs};
+use anyhow::anyhow;
+
+use abq_hosted::AccessToken;
+use serde_derive::{Deserialize, Serialize};
+use etcetera::{app_strategy, AppStrategy, AppStrategyArgs};
+
+#[derive(Deserialize, Serialize)]
+pub struct AbqConfig {
+  pub rwx_access_token: AccessToken,
+}
+
+fn abq_config_filepath() -> anyhow::Result<PathBuf> {
+    let strategy = app_strategy::Unix::new(AppStrategyArgs {
+        top_level_domain: "org".to_string(),
+        author: "rwx".to_string(),
+        app_name: "abq".to_string(),
+    })?;
+    let config_dir = strategy.config_dir();
+    Ok(config_dir.join("config.toml"))
+}
+
+pub fn write_abq_config(config: AbqConfig) -> anyhow::Result<PathBuf> {
+    let abq_config_filepath = abq_config_filepath()?;
+    let config_dir = abq_config_filepath.parent().ok_or(anyhow!("abq config file must have parent dir"))?;
+    fs::create_dir_all(config_dir)?;
+    let toml_str = toml::to_string(&config)?;
+    fs::write(&abq_config_filepath, toml_str)?;
+    Ok(abq_config_filepath)
+}
+
+pub fn read_abq_config() -> anyhow::Result<AbqConfig> {
+    let toml_str = fs::read_to_string(abq_config_filepath()?)?;
+    let config = toml::from_str(&toml_str)?;
+    Ok(config)
+}

--- a/crates/abq_cli/src/abq_config.rs
+++ b/crates/abq_cli/src/abq_config.rs
@@ -24,7 +24,7 @@ pub fn write_abq_config(config: AbqConfig) -> anyhow::Result<PathBuf> {
     let abq_config_filepath = abq_config_filepath()?;
     let config_dir = abq_config_filepath
         .parent()
-        .ok_or(anyhow!("abq config file must have parent dir"))?;
+        .ok_or_else(|| anyhow!("abq config file must have parent dir"))?;
     fs::create_dir_all(config_dir)?;
     let toml_str = toml::to_string(&config)?;
     fs::write(&abq_config_filepath, toml_str)?;

--- a/crates/abq_cli/src/abq_config.rs
+++ b/crates/abq_cli/src/abq_config.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use std::{fs, path::{PathBuf}, env::VarError};
+use std::{env::VarError, fs, path::PathBuf};
 
 use abq_hosted::AccessToken;
 use etcetera::{app_strategy, AppStrategy, AppStrategyArgs};
@@ -13,10 +13,10 @@ pub struct AbqConfig {
 pub fn abq_config_filepath(explicit_config_file: Result<String, VarError>) -> Option<PathBuf> {
     match explicit_config_file {
         Ok(val) => {
-            if val == "" {
+            if val.is_empty() {
                 return None;
             }
-            return Some(PathBuf::from(val));
+            Some(PathBuf::from(val))
         }
         Err(_e) => {
             let strategy = app_strategy::Unix::new(AppStrategyArgs {
@@ -24,7 +24,9 @@ pub fn abq_config_filepath(explicit_config_file: Result<String, VarError>) -> Op
                 author: "rwx".to_string(),
                 app_name: "abq".to_string(),
             });
-            let config_dir = Result::expect(strategy, "failed to build conventional abq config filepath").config_dir();
+            let config_dir =
+                Result::expect(strategy, "failed to build conventional abq config filepath")
+                    .config_dir();
             Some(config_dir.join("config.toml"))
         }
     }
@@ -69,7 +71,10 @@ mod tests {
 
     #[test]
     fn test_abq_filepath_explicit_some() {
-        assert_eq!(abq_config_filepath(Ok("~/my/custom/path".to_string())), Some(PathBuf::from("~/my/custom/path")));
+        assert_eq!(
+            abq_config_filepath(Ok("~/my/custom/path".to_string())),
+            Some(PathBuf::from("~/my/custom/path"))
+        );
     }
 
     #[test]

--- a/crates/abq_cli/src/abq_config.rs
+++ b/crates/abq_cli/src/abq_config.rs
@@ -1,13 +1,13 @@
-use std::{path::{PathBuf}, fs};
 use anyhow::anyhow;
+use std::{fs, path::PathBuf};
 
 use abq_hosted::AccessToken;
-use serde_derive::{Deserialize, Serialize};
 use etcetera::{app_strategy, AppStrategy, AppStrategyArgs};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
 pub struct AbqConfig {
-  pub rwx_access_token: AccessToken,
+    pub rwx_access_token: AccessToken,
 }
 
 fn abq_config_filepath() -> anyhow::Result<PathBuf> {
@@ -22,7 +22,9 @@ fn abq_config_filepath() -> anyhow::Result<PathBuf> {
 
 pub fn write_abq_config(config: AbqConfig) -> anyhow::Result<PathBuf> {
     let abq_config_filepath = abq_config_filepath()?;
-    let config_dir = abq_config_filepath.parent().ok_or(anyhow!("abq config file must have parent dir"))?;
+    let config_dir = abq_config_filepath
+        .parent()
+        .ok_or(anyhow!("abq config file must have parent dir"))?;
     fs::create_dir_all(config_dir)?;
     let toml_str = toml::to_string(&config)?;
     fs::write(&abq_config_filepath, toml_str)?;

--- a/crates/abq_cli/src/abq_config.rs
+++ b/crates/abq_cli/src/abq_config.rs
@@ -1,11 +1,11 @@
 use anyhow::anyhow;
-use std::{fs, path::{PathBuf, Path}};
+use std::{fs, path::PathBuf};
 
 use abq_hosted::AccessToken;
 use etcetera::{app_strategy, AppStrategy, AppStrategyArgs};
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub struct AbqConfig {
     pub rwx_access_token: AccessToken,
 }
@@ -20,7 +20,10 @@ pub fn abq_config_filepath() -> anyhow::Result<PathBuf> {
     Ok(config_dir.join("config.toml"))
 }
 
-pub fn write_abq_config(config: AbqConfig, config_path: anyhow::Result<PathBuf>) -> anyhow::Result<PathBuf> {
+pub fn write_abq_config(
+    config: AbqConfig,
+    config_path: anyhow::Result<PathBuf>,
+) -> anyhow::Result<PathBuf> {
     let abq_config_filepath = config_path?;
     let config_dir = abq_config_filepath
         .parent()
@@ -62,6 +65,9 @@ mod tests {
         let read_config = read_abq_config(config_path);
         assert!(read_config.is_ok());
 
-        assert_eq!(read_config.unwrap().rwx_access_token.to_string(), "testy_mctesterson");
+        assert_eq!(
+            read_config.unwrap().rwx_access_token.to_string(),
+            "testy_mctesterson"
+        );
     }
 }

--- a/crates/abq_cli/src/abq_config.rs
+++ b/crates/abq_cli/src/abq_config.rs
@@ -11,11 +11,11 @@ pub struct AbqConfig {
 }
 
 pub enum AbqConfigFileMode {
-    // Conventional unix location (e.g ~/.config/abq/config.toml)
+    /// Conventional unix location (e.g ~/.config/abq/config.toml)
     Conventional,
-    // Non-standard location (e.g. ~/my/custom/path/config.toml)
+    /// Non-standard location (e.g. ~/my/custom/path/config.toml)
     Override(String),
-    // Ignore any located config file (For instance, if the host machine happens to have a config file)
+    /// Ignore any located config file (For instance, if the host machine happens to have a config file)
     Ignore,
 }
 
@@ -52,14 +52,9 @@ pub fn write_abq_config(
 }
 
 pub fn read_abq_config(path: Option<PathBuf>) -> Option<AbqConfig> {
-    match path {
-        Some(config_path) => {
-            let toml_str = fs::read_to_string(config_path);
-            let config = toml::from_str(&toml_str.ok()?).ok();
-            Some(config?)
-        }
-        None => None,
-    }
+    let path = path?;
+    let toml_str = fs::read_to_string(path).ok()?;
+    toml::from_str(&toml_str).ok()
 }
 
 #[cfg(test)]

--- a/crates/abq_cli/src/abq_config.rs
+++ b/crates/abq_cli/src/abq_config.rs
@@ -90,6 +90,12 @@ mod tests {
     }
 
     #[test]
+    fn test_abq_config_file_missing_returns_none() {
+        let read_config = read_abq_config(Some("/derp/does_not_exist/config.toml".into()));
+        assert!(read_config.is_none());
+    }
+
+    #[test]
     fn test_abq_config_operations() {
         let access_token = AccessToken::from_str("testy_mctesterson").unwrap();
         // Create a temporary directory to store the config file

--- a/crates/abq_cli/src/args.rs
+++ b/crates/abq_cli/src/args.rs
@@ -59,8 +59,7 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Command {
     /// Stores RWX access token.
-    Login {
-    },
+    Login {},
     /// Starts the "abq" ephemeral queue.
     Start {
         /// Host IP address to bind the queue to.

--- a/crates/abq_cli/src/args.rs
+++ b/crates/abq_cli/src/args.rs
@@ -58,7 +58,7 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Command {
-    /// Stores RWX access token.
+    /// Stores an RWX access token for local usage. You can generate RWX Personal Access Tokens at: https://account.rwx.com/_/personal_access_tokens
     Login {},
     /// Starts the "abq" ephemeral queue.
     Start {

--- a/crates/abq_cli/src/args.rs
+++ b/crates/abq_cli/src/args.rs
@@ -59,7 +59,11 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Command {
     /// Stores an RWX access token for local usage. You can generate RWX Personal Access Tokens at: https://account.rwx.com/_/personal_access_tokens
-    Login {},
+    Login {
+        /// The access token to save to the local abq config file.
+        #[clap(long, required = false, env("RWX_ACCESS_TOKEN"))]
+        access_token: Option<AccessToken>,
+    },
     /// Starts the "abq" ephemeral queue.
     Start {
         /// Host IP address to bind the queue to.

--- a/crates/abq_cli/src/args.rs
+++ b/crates/abq_cli/src/args.rs
@@ -58,6 +58,9 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Command {
+    /// Stores RWX access token.
+    Login {
+    },
     /// Starts the "abq" ephemeral queue.
     Start {
         /// Host IP address to bind the queue to.

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -35,7 +35,6 @@ use args::{
 use clap::Parser;
 
 use instance::AbqInstance;
-use std::fs;
 use tracing::{metadata::LevelFilter, Subscriber};
 use tracing_subscriber::{fmt, prelude::*, registry, EnvFilter, Registry};
 use workers::ExecutionMode;
@@ -49,7 +48,6 @@ use crate::{
     },
     reporting::StdoutPreferences,
 };
-use etcetera::{app_strategy, AppStrategy, AppStrategyArgs};
 
 fn main() -> anyhow::Result<()> {
     let exit_code = abq_main()?;
@@ -235,6 +233,8 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
     match command {
         Command::Login {} => {
             let mut input = String::new();
+            println!("Generate a Personal Access Token at https://account.rwx.com/_/personal_access_tokens");
+            println!("\n\n");
             println!("Enter your RWX Personal Access Token:");
 
             io::stdin()
@@ -248,7 +248,10 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             };
             let abq_filepath = abq_config::write_abq_config(new_config)?;
 
-            println!("Your token is now stored in {}", abq_filepath.display());
+            println!(
+                "Your access token is now stored at {}",
+                abq_filepath.display()
+            );
             Ok(ExitCode::SUCCESS)
         }
         Command::Start {

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -7,7 +7,6 @@ mod reporting;
 mod statefile;
 mod workers;
 
-use std::env::VarError;
 use std::io;
 use std::str::FromStr;
 use std::{
@@ -255,7 +254,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
                         config_path.display()
                     );
                 }
-                None => println!("Nothing was written.")
+                None => println!("Nothing was written."),
             }
             Ok(ExitCode::SUCCESS)
         }
@@ -370,7 +369,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             let access_token = access_token.or_else(|| {
                 match abq_config::read_abq_config(get_abq_config_filepath()) {
                     Some(abq_config) => Some(abq_config.rwx_access_token),
-                    None => None
+                    None => None,
                 }
             });
 

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -34,6 +34,7 @@ use clap::Parser;
 use instance::AbqInstance;
 use tracing::{metadata::LevelFilter, Subscriber};
 use tracing_subscriber::{fmt, prelude::*, registry, EnvFilter, Registry};
+use std::fs;
 
 use crate::{
     args::Token,
@@ -44,6 +45,7 @@ use crate::{
     },
     reporting::StdoutPreferences,
 };
+use etcetera::{app_strategy, AppStrategy, AppStrategyArgs};
 
 fn main() -> anyhow::Result<()> {
     let exit_code = abq_main()?;
@@ -216,6 +218,30 @@ fn get_inferred_run_id(run_id_environment: RunIdEnvironment) -> Option<RunId> {
     run_id_result.ok().map(RunId)
 }
 
+
+use std::io;
+use serde::{Deserialize,Serialize};
+use toml::from_str;
+use std::str::FromStr;
+
+#[derive(Deserialize, Serialize)]
+struct AbqConfig {
+    rwx_access_token: String,
+}
+
+fn read_abq_config() -> Result<AbqConfig, Box<dyn std::error::Error>> {
+    let strategy = app_strategy::Unix::new(AppStrategyArgs {
+        top_level_domain: "org".to_string(),
+        author: "rwx".to_string(),
+        app_name: "abq".to_string(),
+    }).unwrap();
+    let config_dir = strategy.config_dir();
+    let config_file = format!("{}/{}", config_dir.to_str().unwrap(), "config.toml");
+    let toml_str = fs::read_to_string(config_file)?;
+    let config = from_str(&toml_str)?;
+    Ok(config)
+}
+
 #[tokio::main(flavor = "multi_thread")]
 async fn abq_main() -> anyhow::Result<ExitCode> {
     use clap::{error::ErrorKind, CommandFactory};
@@ -226,7 +252,40 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
 
     let Cli { command } = Cli::parse();
 
+    match read_abq_config() {
+        Ok(config) => {
+            println!("token: {}", config.rwx_access_token);
+        }
+        Err(e) => {
+            println!("Error: {}", e);
+        }
+    }
+
     match command {
+        Command::Login {} => {
+            let mut input = String::new();
+            println!("Paste your RWX Personal Access Token:");
+
+            io::stdin().read_line(&mut input).expect("Failed to read line");
+
+            input = input.trim().to_string();
+
+            let new_config = AbqConfig {
+                rwx_access_token: input,
+            };
+            let toml_str = toml::to_string(&new_config)?;
+            let strategy = app_strategy::Unix::new(AppStrategyArgs {
+                top_level_domain: "org".to_string(),
+                author: "rwx".to_string(),
+                app_name: "abq".to_string(),
+            }).unwrap();
+            let config_dir = strategy.config_dir();
+            let config_file = format!("{}/{}", config_dir.to_str().unwrap(), "config.toml");
+            std::fs::write(config_file.clone(), toml_str)?;
+
+            println!("Your token is now stored in {}", config_file.as_str());
+            Ok(ExitCode::SUCCESS)
+        }
         Command::Start {
             bind: bind_ip,
             public_ip,
@@ -333,6 +392,15 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
 
             let tls_cert = read_opt_path_bytes(tls_cert)?;
             let tls_key = read_opt_path_bytes(tls_key)?;
+
+            let access_token = access_token.or_else(|| {
+                match read_abq_config() {
+                    Ok(config) => {
+                        Some(AccessToken::from_str(config.rwx_access_token.as_str()).unwrap())
+                    }
+                    Err(_) => None
+                }
+            });
 
             let ResolvedConfig {
                 queue_addr: resolved_queue_addr,

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -246,7 +246,8 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             let new_config = abq_config::AbqConfig {
                 rwx_access_token: AccessToken::from_str(&input)?,
             };
-            let abq_filepath = abq_config::write_abq_config(new_config, abq_config::abq_config_filepath())?;
+            let abq_filepath =
+                abq_config::write_abq_config(new_config, abq_config::abq_config_filepath())?;
 
             println!(
                 "Your access token is now stored at {}",

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -239,7 +239,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
                 None => {
                     let mut input = String::new();
                     println!("Generate a Personal Access Token at https://account.rwx.com/_/personal_access_tokens");
-                    println!("\n\n");
+                    println!("\n");
                     println!("Enter your RWX Personal Access Token:");
 
                     io::stdin()
@@ -254,6 +254,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
 
             if let Some(config_path) = get_abq_config_filepath() {
                 abq_config::write_abq_config(abq_config, Ok(config_path.clone()))?;
+                println!("\n");
                 println!(
                     "Your access token is now stored at: {}",
                     config_path.display()
@@ -391,6 +392,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
                     ErrorKind::InvalidValue,
                     indoc::indoc!("
                     `abq test` was provided a run id, but we've detected an ephemeral queue.
+
                     If you intended to run against a remote queue, please provide an access token by passing `--access-token`, setting `RWX_ACCESS_TOKEN`, or running `abq login`.
                     If you intended to run against an ephemeral queue, please remove the run id argument.
                     ")
@@ -476,6 +478,11 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
 
             let tls_cert = read_opt_path_bytes(tls_cert)?;
 
+            let access_token = access_token.or_else(|| {
+                let config = abq_config::read_abq_config(get_abq_config_filepath())?;
+                Some(config.rwx_access_token)
+            });
+
             let ResolvedConfig {
                 token: resolved_token,
                 tls_cert: resolved_tls,
@@ -491,6 +498,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
                     ErrorKind::InvalidValue,
                     indoc::indoc!("
                     `abq report` was provided a run id, but we've detected an ephemeral queue.
+
                     If you intended to run against a remote queue, please provide an access token by passing `--access-token`, setting `RWX_ACCESS_TOKEN`, or running `abq login`.
                     If you intended to run against an ephemeral queue, please remove the run id argument.
                     ")
@@ -681,10 +689,6 @@ async fn get_config_from_api(
     use abq_hosted::HostedQueueConfig;
 
     let api_url = get_hosted_api_base_url();
-
-    println!("api_url: {}", api_url);
-    println!("access_token: {}", access_token);
-    println!("run_id: {}", run_id);
 
     let HostedQueueConfig {
         addr,

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -1,3 +1,4 @@
+mod abq_config;
 mod args;
 mod health;
 mod instance;
@@ -5,7 +6,6 @@ mod report;
 mod reporting;
 mod statefile;
 mod workers;
-mod abq_config;
 
 use std::io;
 use std::str::FromStr;
@@ -35,9 +35,10 @@ use args::{
 use clap::Parser;
 
 use instance::AbqInstance;
+use std::fs;
 use tracing::{metadata::LevelFilter, Subscriber};
 use tracing_subscriber::{fmt, prelude::*, registry, EnvFilter, Registry};
-use std::fs;
+use workers::ExecutionMode;
 
 use crate::{
     args::Token,
@@ -236,7 +237,9 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             let mut input = String::new();
             println!("Enter your RWX Personal Access Token:");
 
-            io::stdin().read_line(&mut input).expect("Failed to read line");
+            io::stdin()
+                .read_line(&mut input)
+                .expect("Failed to read line");
 
             input = input.trim().to_string();
 
@@ -393,10 +396,10 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
                 Fixed(num) => num,
             };
 
-            let should_send_results = !matches!(
-                rwx_access_token_kind.as_ref(),
-                Some(AccessTokenKind::Personal)
-            );
+            let execution_mode = match rwx_access_token_kind.as_ref() {
+                Some(AccessTokenKind::Personal) => ExecutionMode::Readonly,
+                _ => ExecutionMode::WriteNormal,
+            };
 
             statefile::optional_write_worker_statefile(&run_id)?;
 
@@ -420,7 +423,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
                 abq.negotiator_handle(),
                 abq.client_options().clone(),
                 startup_timeout,
-                should_send_results,
+                execution_mode,
             )
             .await
         }

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -231,24 +231,30 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
     let Cli { command } = Cli::parse();
 
     match command {
-        Command::Login {} => {
-            let mut input = String::new();
-            println!("Generate a Personal Access Token at https://account.rwx.com/_/personal_access_tokens");
-            println!("\n\n");
-            println!("Enter your RWX Personal Access Token:");
+        Command::Login { access_token } => {
+            let abq_config = match access_token {
+                Some(token) => abq_config::AbqConfig {
+                    rwx_access_token: token,
+                },
+                None => {
+                    let mut input = String::new();
+                    println!("Generate a Personal Access Token at https://account.rwx.com/_/personal_access_tokens");
+                    println!("\n\n");
+                    println!("Enter your RWX Personal Access Token:");
 
-            io::stdin()
-                .read_line(&mut input)
-                .expect("Failed to read line");
+                    io::stdin()
+                        .read_line(&mut input)
+                        .expect("Failed to read line");
 
-            input = input.trim().to_string();
-
-            let new_config = abq_config::AbqConfig {
-                rwx_access_token: AccessToken::from_str(&input)?,
+                    abq_config::AbqConfig {
+                        rwx_access_token: AccessToken::from_str(input.trim())?,
+                    }
+                }
             };
+
             match get_abq_config_filepath() {
                 Some(config_path) => {
-                    abq_config::write_abq_config(new_config, Ok(config_path.clone()))?;
+                    abq_config::write_abq_config(abq_config, Ok(config_path.clone()))?;
                     println!(
                         "Your access token is now stored at: {}",
                         config_path.display()

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -653,7 +653,17 @@ async fn resolve_config(
 }
 
 fn get_abq_config_filepath() -> Option<PathBuf> {
-    abq_config::abq_config_filepath(std::env::var("ABQ_CONFIG_FILE"))
+    let config_file_mode = match std::env::var("ABQ_CONFIG_FILE") {
+        Ok(path) => {
+            if path.is_empty() {
+                abq_config::AbqConfigFileMode::Ignore
+            } else {
+                abq_config::AbqConfigFileMode::Override(path)
+            }
+        }
+        Err(_) => abq_config::AbqConfigFileMode::Conventional,
+    };
+    abq_config::abq_config_filepath(config_file_mode)
 }
 
 fn get_hosted_api_base_url() -> String {

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -5,7 +5,10 @@ mod report;
 mod reporting;
 mod statefile;
 mod workers;
+mod abq_config;
 
+use std::io;
+use std::str::FromStr;
 use std::{
     collections::HashMap, net::SocketAddr, num::NonZeroUsize, path::PathBuf, time::Duration,
 };
@@ -218,30 +221,6 @@ fn get_inferred_run_id(run_id_environment: RunIdEnvironment) -> Option<RunId> {
     run_id_result.ok().map(RunId)
 }
 
-
-use std::io;
-use serde::{Deserialize,Serialize};
-use toml::from_str;
-use std::str::FromStr;
-
-#[derive(Deserialize, Serialize)]
-struct AbqConfig {
-    rwx_access_token: String,
-}
-
-fn read_abq_config() -> Result<AbqConfig, Box<dyn std::error::Error>> {
-    let strategy = app_strategy::Unix::new(AppStrategyArgs {
-        top_level_domain: "org".to_string(),
-        author: "rwx".to_string(),
-        app_name: "abq".to_string(),
-    }).unwrap();
-    let config_dir = strategy.config_dir();
-    let config_file = format!("{}/{}", config_dir.to_str().unwrap(), "config.toml");
-    let toml_str = fs::read_to_string(config_file)?;
-    let config = from_str(&toml_str)?;
-    Ok(config)
-}
-
 #[tokio::main(flavor = "multi_thread")]
 async fn abq_main() -> anyhow::Result<ExitCode> {
     use clap::{error::ErrorKind, CommandFactory};
@@ -252,38 +231,21 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
 
     let Cli { command } = Cli::parse();
 
-    match read_abq_config() {
-        Ok(config) => {
-            println!("token: {}", config.rwx_access_token);
-        }
-        Err(e) => {
-            println!("Error: {}", e);
-        }
-    }
-
     match command {
         Command::Login {} => {
             let mut input = String::new();
-            println!("Paste your RWX Personal Access Token:");
+            println!("Enter your RWX Personal Access Token:");
 
             io::stdin().read_line(&mut input).expect("Failed to read line");
 
             input = input.trim().to_string();
 
-            let new_config = AbqConfig {
-                rwx_access_token: input,
+            let new_config = abq_config::AbqConfig {
+                rwx_access_token: AccessToken::from_str(&input)?,
             };
-            let toml_str = toml::to_string(&new_config)?;
-            let strategy = app_strategy::Unix::new(AppStrategyArgs {
-                top_level_domain: "org".to_string(),
-                author: "rwx".to_string(),
-                app_name: "abq".to_string(),
-            }).unwrap();
-            let config_dir = strategy.config_dir();
-            let config_file = format!("{}/{}", config_dir.to_str().unwrap(), "config.toml");
-            std::fs::write(config_file.clone(), toml_str)?;
+            let abq_filepath = abq_config::write_abq_config(new_config)?;
 
-            println!("Your token is now stored in {}", config_file.as_str());
+            println!("Your token is now stored in {}", abq_filepath.display());
             Ok(ExitCode::SUCCESS)
         }
         Command::Start {
@@ -394,12 +356,8 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             let tls_key = read_opt_path_bytes(tls_key)?;
 
             let access_token = access_token.or_else(|| {
-                match read_abq_config() {
-                    Ok(config) => {
-                        Some(AccessToken::from_str(config.rwx_access_token.as_str()).unwrap())
-                    }
-                    Err(_) => None
-                }
+                let config = abq_config::read_abq_config().ok()?;
+                Some(config.rwx_access_token)
             });
 
             let ResolvedConfig {

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use abq_hosted::AccessToken;
+use abq_hosted::AccessTokenKind;
 use abq_utils::{
     auth::{ClientAuthStrategy, ServerAuthStrategy, User, UserToken},
     exit::ExitCode,
@@ -63,7 +64,7 @@ struct ConfigFromApi {
     queue_addr: SocketAddr,
     token: UserToken,
     tls_public_certificate: Option<Vec<u8>>,
-    rwx_access_token_kind: String,
+    rwx_access_token_kind: AccessTokenKind,
 }
 
 struct RunIdEnvironment {
@@ -366,8 +367,8 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
                 Fixed(num) => num,
             };
 
-            let should_send_results = match rwx_access_token_kind.as_ref().map(String::as_ref) {
-                Some("personal_access_token") => false,
+            let should_send_results = match rwx_access_token_kind.as_ref() {
+                Some(AccessTokenKind::Personal) => false,
                 _ => true,
             };
 
@@ -424,7 +425,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
                 queue_addr: resolved_queue_addr,
                 token: resolved_token,
                 tls_cert: resolved_tls,
-                rwx_access_token_kind: resolved_rwx_access_token_kind,
+                rwx_access_token_kind: _resolved_rwx_access_token_kind,
             } = resolve_config(token, queue_addr, tls_cert, &access_token, &run_id)?;
 
             let client_auth = resolved_token.into();
@@ -539,7 +540,7 @@ struct ResolvedConfig {
     queue_addr: Option<SocketAddr>,
     token: Option<UserToken>,
     tls_cert: Option<Vec<u8>>,
-    rwx_access_token_kind: Option<String>,
+    rwx_access_token_kind: Option<AccessTokenKind>,
 }
 
 fn resolve_config(

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -378,8 +378,12 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             if explicit_run_id_provided && !queue_location.is_remote() {
                 let mut cmd = Cli::command();
                 Err(cmd.error(
-                    ErrorKind::MissingRequiredArgument,
-                    "`abq test` was not given an access token and could not infer one. Consider passing `--access-token`, setting `RWX_ACCESS_TOKEN`, or running `abq login`.",
+                    ErrorKind::InvalidValue,
+                    "`abq test` was provided a run id, but we've detected an ephemeral queue.
+
+                    If you intended to run against a remote queue, please provide an access token by passing `--access-token`, setting `RWX_ACCESS_TOKEN`, or running `abq login`.
+                    If you intended to run against an ephemeral queue, please remove the run id argument.
+                    ",
                 ))?;
             }
 
@@ -474,8 +478,12 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             if explicit_run_id_provided && !queue_location.is_remote() {
                 let mut cmd = Cli::command();
                 Err(cmd.error(
-                    ErrorKind::MissingRequiredArgument,
-                    "`abq report` was not given an access token and could not infer one. Consider passing `--access-token`, setting `RWX_ACCESS_TOKEN`, or running `abq login`.",
+                    ErrorKind::InvalidValue,
+                    "`abq report` was provided a run id, but we've detected an ephemeral queue.
+
+                    If you intended to run against a remote queue, please provide an access token by passing `--access-token`, setting `RWX_ACCESS_TOKEN`, or running `abq login`.
+                    If you intended to run against an ephemeral queue, please remove the run id argument.
+                    ",
                 ))?;
             }
 
@@ -649,6 +657,10 @@ async fn get_config_from_api(
     use abq_hosted::HostedQueueConfig;
 
     let api_url = get_hosted_api_base_url();
+
+    println!("api_url: {}", api_url);
+    println!("access_token: {}", access_token);
+    println!("run_id: {}", run_id);
 
     let HostedQueueConfig {
         addr,

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -367,15 +367,23 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             });
 
             let ResolvedConfig {
-                queue_addr: resolved_queue_addr,
                 token: resolved_token,
                 tls_cert: resolved_tls,
                 rwx_access_token_kind,
-            } = resolve_config(token, queue_addr, tls_cert, &access_token, &run_id)?;
+                queue_location,
+            } = resolve_config(token, queue_addr, tls_cert, tls_key, &access_token, &run_id)?;
+
+            if let QueueLocation::Remote(_queue_addr) = queue_location {
+                if access_token.is_none() {
+                    let mut cmd = Cli::command();
+                    Err(cmd.error(
+                        ErrorKind::MissingRequiredArgument,
+                        "`abq test` was not given an access token and could not infer one. Consider passing `--access-token`, setting `RWX_ACCESS_TOKEN`, or running `abq login`.",
+                    ))?;
+                }
+            }
 
             let client_auth = resolved_token.into();
-
-            let queue_addr_or_opt_tls_key = resolved_queue_addr.ok_or(tls_key);
 
             let runner_params = validate_abq_test_args(args)?;
 
@@ -383,7 +391,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             let abq = find_or_create_abq(
                 entity,
                 run_id.clone(),
-                queue_addr_or_opt_tls_key,
+                queue_location,
                 resolved_token,
                 client_auth,
                 resolved_tls,
@@ -454,27 +462,29 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             let tls_cert = read_opt_path_bytes(tls_cert)?;
 
             let ResolvedConfig {
-                queue_addr: resolved_queue_addr,
                 token: resolved_token,
                 tls_cert: resolved_tls,
                 rwx_access_token_kind: _resolved_rwx_access_token_kind,
-            } = resolve_config(token, queue_addr, tls_cert, &access_token, &run_id)?;
+                queue_location,
+            } = resolve_config(token, queue_addr, tls_cert, None, &access_token, &run_id)?;
 
             let client_auth = resolved_token.into();
 
-            let queue_addr = resolved_queue_addr.ok_or_else(|| {
-                let mut cmd = Cli::command();
-                cmd.error(
-                    ErrorKind::InvalidValue,
-                    "`abq report` could not detect the queue to connect to. Consider setting `--access-token` or the `RWX_ACCESS_TOKEN` environment variable.",
-                )
-            })?;
+            if let QueueLocation::Remote(_queue_addr) = queue_location {
+                if access_token.is_none() {
+                    let mut cmd = Cli::command();
+                    Err(cmd.error(
+                        ErrorKind::MissingRequiredArgument,
+                        "`abq report` was not given an access token and could not infer one. Consider passing `--access-token`, setting `RWX_ACCESS_TOKEN`, or running `abq login`.",
+                    ))?;
+                }
+            }
 
             let entity = Entity::local_client();
             let abq = find_or_create_abq(
                 entity,
                 run_id.clone(),
-                Ok(queue_addr),
+                queue_location,
                 resolved_token,
                 client_auth,
                 resolved_tls,
@@ -569,16 +579,22 @@ fn read_path_bytes(p: PathBuf) -> anyhow::Result<Vec<u8>> {
 }
 
 struct ResolvedConfig {
-    queue_addr: Option<SocketAddr>,
     token: Option<UserToken>,
     tls_cert: Option<Vec<u8>>,
     rwx_access_token_kind: Option<AccessTokenKind>,
+    queue_location: QueueLocation,
+}
+
+enum QueueLocation {
+    Remote(SocketAddr),
+    Ephemeral { opt_tls_key: Option<Vec<u8>> },
 }
 
 fn resolve_config(
     token_from_cli: Option<UserToken>,
     queue_addr_from_cli: Option<SocketAddr>,
     tls_cert_from_cli: Option<Vec<u8>>,
+    tls_key: Option<Vec<u8>>,
     access_token: &Option<AccessToken>,
     run_id: &RunId,
 ) -> anyhow::Result<ResolvedConfig> {
@@ -599,12 +615,18 @@ fn resolve_config(
     let token = token_from_api.or(token_from_cli);
     let queue_addr = queue_addr_from_api.or(queue_addr_from_cli);
     let tls_cert = tls_from_api.or(tls_cert_from_cli);
+    let queue_location = match queue_addr {
+        Some(queue_addr) => QueueLocation::Remote(queue_addr),
+        None => QueueLocation::Ephemeral {
+            opt_tls_key: tls_key,
+        },
+    };
 
     Ok(ResolvedConfig {
-        queue_addr,
         token,
         tls_cert,
         rwx_access_token_kind,
+        queue_location,
     })
 }
 
@@ -661,7 +683,7 @@ fn validate_abq_test_args(mut args: Vec<String>) -> Result<NativeTestRunnerParam
 async fn find_or_create_abq(
     entity: Entity,
     run_id: RunId,
-    queue_addr_or_opt_tls: Result<SocketAddr, Option<Vec<u8>>>,
+    queue_location: QueueLocation,
     opt_user_token: Option<UserToken>,
     client_auth: ClientAuthStrategy<User>,
     client_tls_cert: Option<Vec<u8>>,
@@ -672,8 +694,8 @@ async fn find_or_create_abq(
         None => ClientTlsStrategy::no_tls(),
     };
 
-    match queue_addr_or_opt_tls {
-        Ok(queue_addr) => {
+    match queue_location {
+        QueueLocation::Remote(queue_addr) => {
             let instance = AbqInstance::from_remote(
                 entity,
                 run_id,
@@ -684,7 +706,7 @@ async fn find_or_create_abq(
             )?;
             Ok(instance)
         }
-        Err(opt_tls_key) => {
+        QueueLocation::Ephemeral { opt_tls_key } => {
             let server_tls = match (client_tls_cert, opt_tls_key) {
                 (Some(cert), Some(key)) => ServerTlsStrategy::from_cert(&cert, &key)?,
                 (None, None) => ServerTlsStrategy::no_tls(),
@@ -692,7 +714,6 @@ async fn find_or_create_abq(
                     "any other configuration would have been caught during arg parsing"
                 ),
             };
-
             Ok(
                 AbqInstance::new_ephemeral(opt_user_token, client_auth, server_tls, client_tls)
                     .await,

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -246,7 +246,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             let new_config = abq_config::AbqConfig {
                 rwx_access_token: AccessToken::from_str(&input)?,
             };
-            let abq_filepath = abq_config::write_abq_config(new_config)?;
+            let abq_filepath = abq_config::write_abq_config(new_config, abq_config::abq_config_filepath())?;
 
             println!(
                 "Your access token is now stored at {}",
@@ -363,7 +363,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             let tls_key = read_opt_path_bytes(tls_key)?;
 
             let access_token = access_token.or_else(|| {
-                let config = abq_config::read_abq_config().ok()?;
+                let config = abq_config::read_abq_config(abq_config::abq_config_filepath()).ok()?;
                 Some(config.rwx_access_token)
             });
 

--- a/crates/abq_cli/src/workers.rs
+++ b/crates/abq_cli/src/workers.rs
@@ -175,12 +175,17 @@ async fn do_shutdown(
         .unwrap();
     print!("\n\n");
     match execution_mode {
-        ExecutionMode::WriteNormal => print!(
-            "abq test --run-id {} --worker {} --num {}",
-            run_id,
-            worker_tag.index(),
-            num_runners
-        ),
+        ExecutionMode::WriteNormal => {
+            print!("To replay these tests locally login with `abq login` using a personal access token. Then, run the following command:");
+            print!("\n\n");
+            print!(
+                "abq test --run-id {} --worker {} --num {}",
+                run_id,
+                worker_tag.index(),
+                num_runners
+            );
+            print!("\n\n");
+        }
         _ => {}
     }
 

--- a/crates/abq_cli/src/workers.rs
+++ b/crates/abq_cli/src/workers.rs
@@ -29,7 +29,7 @@ use self::reporting::ReportingTaskHandle;
 
 type ClientOptions = abq_utils::net_opt::ClientOptions<abq_utils::auth::User>;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecutionMode {
     WriteNormal,
     Readonly,
@@ -174,19 +174,16 @@ async fn do_shutdown(
         .write_short_summary_lines(&mut stdout, ShortSummaryGrouping::Runner)
         .unwrap();
     print!("\n\n");
-    match execution_mode {
-        ExecutionMode::WriteNormal => {
-            print!("To replay these tests locally login with `abq login` using a personal access token. Then, run the following command:");
-            print!("\n\n");
-            print!(
-                "abq test --run-id {} --worker {} --num {}",
-                run_id,
-                worker_tag.index(),
-                num_runners
-            );
-            print!("\n\n");
-        }
-        _ => {}
+    if execution_mode == ExecutionMode::WriteNormal {
+        print!("To replay these tests locally login with `abq login` using a personal access token. Then, run the following command:");
+        print!("\n\n");
+        print!(
+            "abq test --run-id {} --worker {} --num {}",
+            run_id,
+            worker_tag.index(),
+            num_runners
+        );
+        print!("\n\n");
     }
 
     // If the workers didn't fault, exit with whatever status the test suite run is at; otherwise,

--- a/crates/abq_cli/src/workers.rs
+++ b/crates/abq_cli/src/workers.rs
@@ -175,7 +175,7 @@ async fn do_shutdown(
         .unwrap();
     print!("\n\n");
     if execution_mode == ExecutionMode::WriteNormal {
-        print!("To replay these tests locally login with `abq login` using a personal access token. Then, run the following command:");
+        print!("Run the following command to replay these tests locally:");
         print!("\n\n");
         print!(
             "abq test --run-id {} --worker {} --num {}",

--- a/crates/abq_cli/src/workers.rs
+++ b/crates/abq_cli/src/workers.rs
@@ -3,6 +3,7 @@ use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::Duration;
 
+use abq_hosted::record_test_run_metadata;
 use abq_reporting::output::ShortSummaryGrouping;
 use abq_reporting::CompletedSummary;
 use abq_utils::capture_output::ProcessOutput;
@@ -43,6 +44,7 @@ pub async fn start_workers_standalone(
     queue_negotiator: QueueNegotiatorHandle,
     client_opts: ClientOptions,
     startup_timeout: Duration,
+    should_send_results: bool,
 ) -> ! {
     let test_suite_name = "suite"; // TODO: determine this correctly
     let has_stdout_reporters = reporter_kinds
@@ -73,6 +75,7 @@ pub async fn start_workers_standalone(
         test_timeout,
         results_batch_size_hint: batch_size.get(),
         max_run_number,
+        should_send_results
     };
 
     tracing::debug!(

--- a/crates/abq_cli/src/workers.rs
+++ b/crates/abq_cli/src/workers.rs
@@ -3,7 +3,6 @@ use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::Duration;
 
-
 use abq_reporting::output::ShortSummaryGrouping;
 use abq_reporting::CompletedSummary;
 use abq_utils::capture_output::ProcessOutput;
@@ -75,7 +74,7 @@ pub async fn start_workers_standalone(
         test_timeout,
         results_batch_size_hint: batch_size.get(),
         max_run_number,
-        should_send_results
+        should_send_results,
     };
 
     tracing::debug!(

--- a/crates/abq_cli/src/workers.rs
+++ b/crates/abq_cli/src/workers.rs
@@ -184,6 +184,7 @@ async fn do_shutdown(
             num_runners
         );
         print!("\n\n");
+        print!("Specify your Access Token with the RWX_ACCESS_TOKEN env variable, passing --access-token, or running `abq login`.");
     }
 
     // If the workers didn't fault, exit with whatever status the test suite run is at; otherwise,

--- a/crates/abq_cli/src/workers.rs
+++ b/crates/abq_cli/src/workers.rs
@@ -173,18 +173,18 @@ async fn do_shutdown(
     suite_result
         .write_short_summary_lines(&mut stdout, ShortSummaryGrouping::Runner)
         .unwrap();
-    print!("\n\n");
+    println!("\n");
     if execution_mode == ExecutionMode::WriteNormal {
-        print!("Run the following command to replay these tests locally:");
-        print!("\n\n");
-        print!(
-            "abq test --run-id {} --worker {} --num {}",
+        println!("Run the following command to replay these tests locally:");
+        println!("\n");
+        println!(
+            "\tabq test --run-id {} --worker {} --num {} -- <your-test-command>",
             run_id,
             worker_tag.index(),
-            num_runners
+            num_runners,
         );
-        print!("\n\n");
-        print!("Specify your Access Token with the RWX_ACCESS_TOKEN env variable, passing --access-token, or running `abq login`.");
+        println!("\n");
+        println!("Specify your Access Token with the RWX_ACCESS_TOKEN env variable, passing --access-token, or running `abq login`.");
     }
 
     // If the workers didn't fault, exit with whatever status the test suite run is at; otherwise,

--- a/crates/abq_cli/src/workers.rs
+++ b/crates/abq_cli/src/workers.rs
@@ -3,7 +3,7 @@ use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::Duration;
 
-use abq_hosted::record_test_run_metadata;
+
 use abq_reporting::output::ShortSummaryGrouping;
 use abq_reporting::CompletedSummary;
 use abq_utils::capture_output::ProcessOutput;

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -2623,7 +2623,10 @@ fn personal_access_token_does_not_mutate_remote_queue() {
             args
         };
 
-        let CmdOutput { .. } = Abq::new(format!("{name}_initial")).args(test_args).run();
+        let CmdOutput { .. } = Abq::new(format!("{name}_initial"))
+            .args(test_args)
+            .env([("ABQ_CONFIG_FILE", "")])
+            .run();
 
         // abq report --reporter dot --queue-addr ... --run-id ... (--token ...)?
         let report_args = {

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -2910,13 +2910,20 @@ fn report_while_run_in_progress_is_error() {
 #[serial]
 fn test_explicit_run_id_against_ephemeral_queue() {
     let name = "test_explicit_run_id_against_ephemeral_queue";
+    let args = vec![
+        format!("test"),
+        format!("--worker=1"),
+        format!("--run-id=test-run-id"),
+        format!("-n=1"),
+        s!("--"),
+        format!("some_test_command"),
+    ];
+
     let CmdOutput {
         exit_status,
         stderr,
         stdout,
-    } = Abq::new(format!("{name}_initial"))
-        .args(["--run-id", "test-run-id", "--", "false"])
-        .run();
+    } = Abq::new(format!("{name}_initial")).args(args).run();
     assert!(
         !exit_status.success(),
         "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -17,6 +17,7 @@ use abq_utils::net_protocol::runners::{
 };
 use abq_with_protocol_version::with_protocol_version;
 use indoc::formatdoc;
+use mockito::{Matcher, Server};
 use regex::Regex;
 use serde_json as json;
 use serial_test::serial;
@@ -41,6 +42,10 @@ const TLS_CERT_STRING: &str = include_str!(std::concat!(
     "testdata/certs/server.crt"
 ));
 const TLS_KEY: &str = std::concat!(std::env!("ABQ_WORKSPACE_DIR"), "testdata/certs/server.key");
+
+fn test_access_token() -> AccessToken {
+    AccessToken::from_str("abqapi_MD2QPKH2VZU2krvOa2mN54Q4qwzNxF").unwrap()
+}
 
 fn var_flag_set(var: &str) -> bool {
     match std::env::var(var) {
@@ -2541,16 +2546,6 @@ fn out_of_process_retries_smoke() {
     );
 
     term(queue_proc);
-}
-
-use mockito::{Matcher, Server};
-
-fn test_access_token() -> AccessToken {
-    AccessToken::from_str("abqapi_MD2QPKH2VZU2krvOa2mN54Q4qwzNxF").unwrap()
-}
-
-fn test_auth_token() -> UserToken {
-    UserToken::from_str("abqs_MD2QPKH2VZU2krvOa2mN54Q4qwzNxF").unwrap()
 }
 
 #[test]

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -2540,7 +2540,6 @@ fn out_of_process_retries_smoke() {
     term(queue_proc);
 }
 
-
 use mockito::{Matcher, Server};
 
 fn test_access_token() -> AccessToken {
@@ -2636,9 +2635,8 @@ fn personal_access_token_does_not_mutate_remote_queue() {
             args
         };
 
-        let CmdOutput { exit_status, .. } = Abq::new(format!("{name}_initial"))
-            .args(test_args)
-            .run();
+        let CmdOutput { exit_status, .. } =
+            Abq::new(format!("{name}_initial")).args(test_args).run();
 
         // abq report --reporter dot --queue-addr ... --run-id ... (--token ...)?
         let report_args = {
@@ -2744,7 +2742,12 @@ fn personal_access_token_does_not_mutate_remote_queue() {
             args
         };
 
-        let CmdOutput { exit_status, stdout, stderr, .. } = Abq::new(format!("{name}_initial"))
+        let CmdOutput {
+            exit_status,
+            stdout,
+            stderr,
+            ..
+        } = Abq::new(format!("{name}_initial"))
             .args(test_args)
             .env([("ABQ_API", server.url())])
             .run();

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -2565,7 +2565,6 @@ fn out_of_process_retries_smoke() {
 #[test]
 #[with_protocol_version]
 #[serial]
-#[ignore]
 fn personal_access_token_does_not_mutate_remote_queue() {
     let name = "personal_access_token_does_not_mutate_remote_queue";
     let conf = CSConfigOptions {

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -2565,6 +2565,7 @@ fn out_of_process_retries_smoke() {
 #[test]
 #[with_protocol_version]
 #[serial]
+#[ignore]
 fn personal_access_token_does_not_mutate_remote_queue() {
     let name = "personal_access_token_does_not_mutate_remote_queue";
     let conf = CSConfigOptions {

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -2,6 +2,7 @@
 // For convenience in tests.
 #![allow(clippy::useless_format)]
 
+use crate::json::json;
 use abq_hosted::AccessToken;
 use abq_native_runner_simulation::{pack, pack_msgs, pack_msgs_to_disk, Msg::*};
 use abq_test_utils::{artifacts_dir, s, sanitize_output, write_to_temp, WORKSPACE};
@@ -35,6 +36,10 @@ use tempfile::{NamedTempFile, TempDir};
 use abq_utils::net_protocol::workers::RunId;
 
 const TLS_CERT: &str = std::concat!(std::env!("ABQ_WORKSPACE_DIR"), "testdata/certs/server.crt");
+const TLS_CERT_STRING: &str = include_str!(std::concat!(
+    std::env!("ABQ_WORKSPACE_DIR"),
+    "testdata/certs/server.crt"
+));
 const TLS_KEY: &str = std::concat!(std::env!("ABQ_WORKSPACE_DIR"), "testdata/certs/server.key");
 
 fn var_flag_set(var: &str) -> bool {
@@ -2672,13 +2677,13 @@ fn personal_access_token_does_not_mutate_remote_queue() {
         )]))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(format!(
-            r#"{{"queue_url":"abqs://{}?run_id={}\u0026token={}","tls_public_certificate":"{}","rwx_access_token_kind":"personal_access_token"}}"#,
-            queue_addr,
-            in_run_id,
-            TEST_USER_AUTH_TOKEN,
-            TLS_CERT,
-        ))
+        .with_body(
+            json!({
+                "queue_url": format!("abqs://{}?run_id={}&token={}", queue_addr, in_run_id, TEST_USER_AUTH_TOKEN),
+                "tls_public_certificate": TLS_CERT_STRING,
+                "rwx_access_token_kind": "personal_access_token",
+            }).to_string()
+        )
         .create();
 
     // simulation 2 - observe passing locally, but still reported as failure remotely
@@ -2734,7 +2739,10 @@ fn personal_access_token_does_not_mutate_remote_queue() {
             exit_status,
             stderr,
             stdout,
-        } = Abq::new(format!("{name}_initial")).args(test_args).run();
+        } = Abq::new(format!("{name}_initial"))
+            .args(test_args)
+            .env([("ABQ_API", server.url())])
+            .run();
 
         assert!(
             exit_status.success(),
@@ -2771,7 +2779,7 @@ fn personal_access_token_does_not_mutate_remote_queue() {
             "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
         );
         assert!(
-            stdout.contains("1 test, 1 failure"),
+            stdout.contains("1 tests, 1 failures"),
             "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
         );
     }
@@ -2885,6 +2893,183 @@ fn report_while_run_in_progress_is_error() {
     );
 
     term(worker0);
+    term(queue_proc);
+}
+
+#[test]
+#[with_protocol_version]
+#[serial]
+fn test_explicit_run_id_against_ephemeral_queue() {
+    let name = "test_explicit_run_id_against_ephemeral_queue";
+    let conf = CSConfigOptions {
+        use_auth_token: true,
+        tls: true,
+    };
+    let (queue_proc, ..) = setup_queue!(name, conf);
+    let manifest = vec![TestOrGroup::test(Test::new(
+        proto,
+        "some_test",
+        [],
+        Default::default(),
+    ))];
+    let proto = AbqProtocolVersion::V0_2.get_supported_witness().unwrap();
+    let manifest = ManifestMessage::new(Manifest::new(manifest, Default::default()));
+
+    {
+        let simulation = [
+            Connect,
+            //
+            // Write spawn message
+            OpaqueWrite(pack(legal_spawned_message(proto))),
+            //
+            // Write the manifest if we need to.
+            // Otherwise handle the one test.
+            IfGenerateManifest {
+                then_do: vec![OpaqueWrite(pack(&manifest))],
+                else_do: {
+                    let mut run_tests = vec![
+                        //
+                        // Read init context message + write ACK
+                        OpaqueRead,
+                        OpaqueWrite(pack(InitSuccessMessage::new(proto))),
+                    ];
+
+                    // If the socket is alive (i.e. we have a test to run), pull it and give back a
+                    // faux result.
+                    // Otherwise assume we ran out of tests on our node and exit.
+                    run_tests.push(IfAliveReadAndWriteFake(Status::Failure {
+                        exception: None,
+                        backtrace: None,
+                    }));
+                    run_tests
+                },
+            },
+            //
+            // Finish
+            Exit(0),
+        ];
+
+        let packed = pack_msgs_to_disk(simulation);
+
+        let test_args = {
+            let simulator = native_runner_simulation_bin();
+            let simfile_path = packed.path.display().to_string();
+            let args = vec![
+                format!("test"),
+                format!("--worker=1"),
+                format!("--run-id=test-run-id"),
+                format!("-n=1"),
+            ];
+            let mut args = conf.extend_args_for_client(args);
+            args.extend([s!("--"), simulator, simfile_path]);
+            args
+        };
+
+        let CmdOutput {
+            exit_status,
+            stderr,
+            stdout,
+        } = Abq::new(format!("{name}_initial")).args(test_args).run();
+
+        assert!(
+            !exit_status.success(),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(
+                "`abq test` was provided a run id, but we've detected an ephemeral queue."
+            ),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+    }
+
+    term(queue_proc);
+}
+
+#[test]
+#[with_protocol_version]
+#[serial]
+fn report_explicit_run_id_against_ephemeral_queue() {
+    let name = "report_explicit_run_id_against_ephemeral_queue";
+    let conf = CSConfigOptions {
+        use_auth_token: true,
+        tls: true,
+    };
+    let (queue_proc, ..) = setup_queue!(name, conf);
+    let manifest = vec![TestOrGroup::test(Test::new(
+        proto,
+        "some_test",
+        [],
+        Default::default(),
+    ))];
+    let proto = AbqProtocolVersion::V0_2.get_supported_witness().unwrap();
+    let manifest = ManifestMessage::new(Manifest::new(manifest, Default::default()));
+
+    {
+        let simulation = [
+            Connect,
+            //
+            // Write spawn message
+            OpaqueWrite(pack(legal_spawned_message(proto))),
+            //
+            // Write the manifest if we need to.
+            // Otherwise handle the one test.
+            IfGenerateManifest {
+                then_do: vec![OpaqueWrite(pack(&manifest))],
+                else_do: {
+                    let mut run_tests = vec![
+                        //
+                        // Read init context message + write ACK
+                        OpaqueRead,
+                        OpaqueWrite(pack(InitSuccessMessage::new(proto))),
+                    ];
+
+                    // If the socket is alive (i.e. we have a test to run), pull it and give back a
+                    // faux result.
+                    // Otherwise assume we ran out of tests on our node and exit.
+                    run_tests.push(IfAliveReadAndWriteFake(Status::Failure {
+                        exception: None,
+                        backtrace: None,
+                    }));
+                    run_tests
+                },
+            },
+            //
+            // Finish
+            Exit(0),
+        ];
+
+        let report_args = {
+            let args = vec![
+                format!("report"),
+                format!("--reporter=dot"),
+                format!("--run-id=some-run-id"),
+                format!("--color=never"),
+            ];
+            conf.extend_args_for_client(args)
+        };
+
+        let CmdOutput {
+            stdout,
+            stderr,
+            exit_status,
+        } = Abq::new(name.to_string() + "_report")
+            .args(report_args)
+            .always_capture_stderr(true)
+            .run();
+
+        assert!(
+            !exit_status.success(),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(
+                "`abq report` was provided a run id, but we've detected an ephemeral queue."
+            ),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+    }
+
     term(queue_proc);
 }
 

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -2992,8 +2992,8 @@ fn login_saves_access_token_custom() {
 #[test]
 #[with_protocol_version]
 #[serial]
-fn login_saves_access_token_noop() {
-    let name = "login_saves_access_token_noop";
+fn login_saves_access_token_err() {
+    let name = "login_saves_access_token_err";
 
     let CmdOutput {
         stdout,

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -2,6 +2,7 @@
 // For convenience in tests.
 #![allow(clippy::useless_format)]
 
+use abq_hosted::AccessToken;
 use abq_native_runner_simulation::{pack, pack_msgs, pack_msgs_to_disk, Msg::*};
 use abq_test_utils::{artifacts_dir, s, sanitize_output, write_to_temp, WORKSPACE};
 use abq_utils::auth::{AdminToken, UserToken};
@@ -21,6 +22,7 @@ use serial_test::serial;
 use std::fs::File;
 use std::ops::{Deref, DerefMut};
 use std::process::{ChildStderr, ChildStdout, ExitStatus, Output};
+use std::str::FromStr;
 use std::thread;
 use std::time::Duration;
 use std::{
@@ -380,9 +382,11 @@ fn wait_for_live_queue(queue_stdout: &mut ChildStdout) {
 fn wait_for_live_worker(worker_stderr: &mut ChildStderr) {
     let mut worker_reader = BufReader::new(worker_stderr).lines();
     // Spin until we know the worker0 is UP
+    eprintln!("HI");
     loop {
         if let Some(line) = worker_reader.next() {
             let line = line.expect("line is not a string");
+            eprintln!("{}", line);
             if line.contains("Generic test runner for") {
                 break;
             }
@@ -2532,6 +2536,258 @@ fn out_of_process_retries_smoke() {
         stdout.contains("64 tests, 64 failures, 64 retried"),
         "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
     );
+
+    term(queue_proc);
+}
+
+
+use mockito::{Matcher, Server};
+
+fn test_access_token() -> AccessToken {
+    AccessToken::from_str("abqapi_MD2QPKH2VZU2krvOa2mN54Q4qwzNxF").unwrap()
+}
+
+fn test_auth_token() -> UserToken {
+    UserToken::from_str("abqs_MD2QPKH2VZU2krvOa2mN54Q4qwzNxF").unwrap()
+}
+
+fn test_mock_cert() -> String {
+    "\
+    -----BEGIN CERTIFICATE-----\
+    FAKEFAKEFAKEFAKEFAKEFAKEFAKE\
+    -----END CERTIFICATE-----\
+    "
+    .to_string()
+}
+
+#[test]
+#[with_protocol_version]
+#[serial]
+fn personal_access_token_does_not_mutate_remote_queue() {
+    let name = "personal_access_token_does_not_mutate_remote_queue";
+    let conf = CSConfigOptions {
+        use_auth_token: true,
+        tls: true,
+    };
+
+    let (queue_proc, queue_addr) = setup_queue!(name, conf);
+
+    let mut manifest = vec![];
+
+    manifest.push(TestOrGroup::test(Test::new(
+        proto,
+        "some_test",
+        [],
+        Default::default(),
+    )));
+
+    let proto = AbqProtocolVersion::V0_2.get_supported_witness().unwrap();
+
+    let manifest = ManifestMessage::new(Manifest::new(manifest, Default::default()));
+
+    {
+        let simulation = [
+            Connect,
+            //
+            // Write spawn message
+            OpaqueWrite(pack(legal_spawned_message(proto))),
+            //
+            // Write the manifest if we need to.
+            // Otherwise handle the one test.
+            IfGenerateManifest {
+                then_do: vec![OpaqueWrite(pack(&manifest))],
+                else_do: {
+                    let mut run_tests = vec![
+                        //
+                        // Read init context message + write ACK
+                        OpaqueRead,
+                        OpaqueWrite(pack(InitSuccessMessage::new(proto))),
+                    ];
+
+                    // If the socket is alive (i.e. we have a test to run), pull it and give back a
+                    // faux result.
+                    // Otherwise assume we ran out of tests on our node and exit.
+                    run_tests.push(IfAliveReadAndWriteFake(Status::Failure {
+                        exception: None,
+                        backtrace: None,
+                    }));
+                    run_tests
+                },
+            },
+            //
+            // Finish
+            Exit(0),
+        ];
+
+        let packed = pack_msgs_to_disk(simulation);
+
+        let test_args = {
+            let simulator = native_runner_simulation_bin();
+            let simfile_path = packed.path.display().to_string();
+            let args = vec![
+                format!("test"),
+                format!("--worker=1"),
+                format!("--queue-addr={queue_addr}"),
+                format!("--run-id=test-run-id"),
+                format!("-n=1"),
+            ];
+            let mut args = conf.extend_args_for_client(args);
+            args.extend([s!("--"), simulator, simfile_path]);
+            args
+        };
+
+        let CmdOutput { exit_status, .. } = Abq::new(format!("{name}_initial"))
+            .args(test_args)
+            .run();
+
+        // abq report --reporter dot --queue-addr ... --run-id ... (--token ...)?
+        let report_args = {
+            let args = vec![
+                format!("report"),
+                format!("--reporter=dot"),
+                format!("--queue-addr={queue_addr}"),
+                format!("--run-id=test-run-id"),
+                format!("--color=never"),
+            ];
+            conf.extend_args_for_client(args)
+        };
+
+        let CmdOutput {
+            stdout,
+            stderr,
+            exit_status,
+        } = Abq::new(name.to_string() + "_report")
+            .args(report_args)
+            .always_capture_stderr(true)
+            .run();
+
+        assert!(
+            !exit_status.success(),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+        assert!(
+            stdout.contains("1 tests, 1 failures"),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+    }
+
+    let mut server = Server::new();
+    let in_run_id = RunId("test-run-id".to_string());
+    let access_token = test_auth_token();
+    let _m = server.mock("GET", "/queue")
+        .match_header(
+            "Authorization",
+            format!("Bearer {}", test_access_token()).as_str(),
+        )
+        .match_header("User-Agent", format!("abq/{}", abq_utils::VERSION).as_str())
+        .match_query(Matcher::AnyOf(vec![Matcher::UrlEncoded(
+            "run_id".to_string(),
+            in_run_id.to_string(),
+        )]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{"queue_url":"abqs://{}?run_id={}\u0026token={}","tls_public_certificate":"{}","rwx_access_token_kind":"personal_access_token"}}"#,
+            queue_addr,
+            in_run_id,
+            TEST_USER_AUTH_TOKEN,
+            TLS_CERT,
+        ))
+        .create();
+
+    // simulation 2
+    {
+        let simulation = [
+            Connect,
+            //
+            // Write spawn message
+            OpaqueWrite(pack(legal_spawned_message(proto))),
+            //
+            // Write the manifest if we need to.
+            // Otherwise handle the one test.
+            IfGenerateManifest {
+                then_do: vec![OpaqueWrite(pack(&manifest))],
+                else_do: {
+                    let mut run_tests = vec![
+                        //
+                        // Read init context message + write ACK
+                        OpaqueRead,
+                        OpaqueWrite(pack(InitSuccessMessage::new(proto))),
+                    ];
+
+                    // If the socket is alive (i.e. we have a test to run), pull it and give back a
+                    // faux result.
+                    // Otherwise assume we ran out of tests on our node and exit.
+                    run_tests.push(IfAliveReadAndWriteFake(Status::Success));
+                    run_tests
+                },
+            },
+            //
+            // Finish
+            Exit(0),
+        ];
+
+        let packed = pack_msgs_to_disk(simulation);
+
+        let test_args = {
+            let simulator = native_runner_simulation_bin();
+            let simfile_path = packed.path.display().to_string();
+            let args = vec![
+                format!("test"),
+                format!("--worker=1"),
+                format!("--run-id=test-run-id"),
+                format!("--access-token={access_token}"),
+                format!("-n=1"),
+            ];
+            let mut args = conf.extend_args_for_client(args);
+            args.extend([s!("--"), simulator, simfile_path]);
+            args
+        };
+
+        let CmdOutput { exit_status, stdout, stderr, .. } = Abq::new(format!("{name}_initial"))
+            .args(test_args)
+            .env([("ABQ_API", server.url())])
+            .run();
+
+        assert!(
+            exit_status.success(),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+        assert!(
+            stdout.contains("1 tests, 0 failures"),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+
+        // abq report --reporter dot --queue-addr ... --run-id ... (--token ...)?
+        let report_args = {
+            let args = vec![
+                format!("report"),
+                format!("--reporter=dot"),
+                format!("--queue-addr={queue_addr}"),
+                format!("--run-id=test-run-id"),
+                format!("--color=never"),
+            ];
+            conf.extend_args_for_client(args)
+        };
+
+        let CmdOutput {
+            stdout,
+            stderr,
+            exit_status,
+        } = Abq::new(name.to_string() + "_report")
+            .args(report_args)
+            .always_capture_stderr(true)
+            .run();
+
+        assert!(
+            !exit_status.success(),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+        assert!(
+            stdout.contains("1 test, 1 failure"),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+    }
 
     term(queue_proc);
 }

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -3031,6 +3031,62 @@ fn report_explicit_run_id_against_ephemeral_queue() {
 }
 
 #[test]
+#[with_protocol_version]
+#[serial]
+fn login_saves_access_token_custom() {
+    let name = "login_saves_access_token_custom";
+    let tempfile = NamedTempFile::new().expect("Failed to create tempfile");
+
+    let CmdOutput {
+        stdout,
+        stderr,
+        exit_status,
+    } = Abq::new(name.to_string() + "_login")
+        .args(vec!["login", "--access-token=testy"])
+        .env([("ABQ_CONFIG_FILE", tempfile.path().to_str().unwrap())])
+        .always_capture_stderr(true)
+        .run();
+
+    assert!(
+        exit_status.success(),
+        "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+    );
+    assert!(
+        stdout.contains(&format!(
+            "Your access token is now stored at: {}",
+            tempfile.path().display()
+        )),
+        "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+    );
+}
+
+#[test]
+#[with_protocol_version]
+#[serial]
+fn login_saves_access_token_noop() {
+    let name = "login_saves_access_token_noop";
+
+    let CmdOutput {
+        stdout,
+        stderr,
+        exit_status,
+    } = Abq::new(name.to_string() + "_login")
+        .args(vec!["login", "--access-token=testy"])
+        .env([("ABQ_CONFIG_FILE", "")])
+        .always_capture_stderr(true)
+        .run();
+
+    assert!(
+        exit_status.success(),
+        "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+    );
+    assert!(
+        stdout.contains(&format!("Nothing was written.")),
+        "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+    );
+}
+
+#[test]
 #[serial]
 fn report_while_run_is_out_of_process_retried_is_error() {
     let name = "report_while_run_is_out_of_process_retried_is_error";

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -382,11 +382,9 @@ fn wait_for_live_queue(queue_stdout: &mut ChildStdout) {
 fn wait_for_live_worker(worker_stderr: &mut ChildStderr) {
     let mut worker_reader = BufReader::new(worker_stderr).lines();
     // Spin until we know the worker0 is UP
-    eprintln!("HI");
     loop {
         if let Some(line) = worker_reader.next() {
             let line = line.expect("line is not a string");
-            eprintln!("{}", line);
             if line.contains("Generic test runner for") {
                 break;
             }

--- a/crates/abq_cli/tests/snapshots/cli__retries_displays_retry_banners.snap
+++ b/crates/abq_cli/tests/snapshots/cli__retries_displays_retry_banners.snap
@@ -42,4 +42,4 @@ Run the following command to replay these tests locally:
 
 abq test --run-id test-run-id --worker 0 --num 1
 
-
+Specify your Access Token with the RWX_ACCESS_TOKEN env variable, passing --access-token, or running `abq login`.

--- a/crates/abq_cli/tests/snapshots/cli__retries_displays_retry_banners.snap
+++ b/crates/abq_cli/tests/snapshots/cli__retries_displays_retry_banners.snap
@@ -37,3 +37,9 @@ Failures:
     runner N:
        64   a/b/x.file
 
+
+Run the following command to replay these tests locally:
+
+abq test --run-id test-run-id --worker 0 --num 1
+
+

--- a/crates/abq_cli/tests/snapshots/cli__retries_displays_retry_banners.snap
+++ b/crates/abq_cli/tests/snapshots/cli__retries_displays_retry_banners.snap
@@ -40,6 +40,9 @@ Failures:
 
 Run the following command to replay these tests locally:
 
-abq test --run-id test-run-id --worker 0 --num 1
+
+	abq test --run-id test-run-id --worker 0 --num 1 -- <your-test-command>
+
 
 Specify your Access Token with the RWX_ACCESS_TOKEN env variable, passing --access-token, or running `abq login`.
+

--- a/crates/abq_hosted/Cargo.toml
+++ b/crates/abq_hosted/Cargo.toml
@@ -18,4 +18,4 @@ default-features = false
 features = ["blocking", "json", "rustls-tls"]
 
 [dev-dependencies]
-mockito = "1.0.1"
+mockito.workspace = true

--- a/crates/abq_hosted/Cargo.toml
+++ b/crates/abq_hosted/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 abq_utils = { path = "../abq_utils" }
 
 serde.workspace = true
+serde_derive.workspace = true
 url = { version = "2.3.1", features = ["serde"] }
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/abq_hosted/Cargo.toml
+++ b/crates/abq_hosted/Cargo.toml
@@ -11,11 +11,12 @@ serde_derive.workspace = true
 url = { version = "2.3.1", features = ["serde"] }
 thiserror.workspace = true
 tracing.workspace = true
+tokio.workspace = true
 
 [dependencies.reqwest]
 version = "0.11.15"
 default-features = false
-features = ["blocking", "json", "rustls-tls"]
+features = ["json", "rustls-tls"]
 
 [dev-dependencies]
 mockito.workspace = true

--- a/crates/abq_hosted/src/access_token.rs
+++ b/crates/abq_hosted/src/access_token.rs
@@ -2,9 +2,10 @@
 
 use core::fmt;
 use std::str::FromStr;
+use serde_derive::{Serialize, Deserialize};
 use thiserror::Error;
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct AccessToken(String);
 
 #[derive(Debug, Error)]

--- a/crates/abq_hosted/src/access_token.rs
+++ b/crates/abq_hosted/src/access_token.rs
@@ -1,8 +1,8 @@
 //! Utilities for interacting with the queue config API
 
 use core::fmt;
+use serde_derive::{Deserialize, Serialize};
 use std::str::FromStr;
-use serde_derive::{Serialize, Deserialize};
 use thiserror::Error;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]

--- a/crates/abq_hosted/src/config.rs
+++ b/crates/abq_hosted/src/config.rs
@@ -18,12 +18,14 @@ pub struct HostedQueueConfig {
     pub auth_token: UserToken,
     /// `Some` is TLS should be used, `None` otherwise.
     pub tls_public_certificate: Option<Vec<u8>>,
+    pub rwx_access_token_kind: String,
 }
 
 #[derive(Deserialize, Debug)]
 struct HostedQueueResponse {
     queue_url: Url,
     tls_public_certificate: Option<String>,
+    rwx_access_token_kind: String,
 }
 
 impl HostedQueueConfig {
@@ -62,6 +64,7 @@ impl HostedQueueConfig {
         let HostedQueueResponse {
             queue_url,
             tls_public_certificate,
+            rwx_access_token_kind,
         } = resp;
 
         let addr = match queue_url.socket_addrs(|| None).as_deref() {
@@ -100,6 +103,7 @@ impl HostedQueueConfig {
             run_id: resolved_run_id,
             auth_token,
             tls_public_certificate: tls_public_certificate.map(String::into_bytes),
+            rwx_access_token_kind
         })
     }
 }
@@ -230,6 +234,7 @@ mod test {
             run_id,
             auth_token,
             tls_public_certificate,
+            rwx_access_token_kind
         } = HostedQueueConfig::from_api(server.url(), &test_access_token(), &in_run_id).unwrap();
 
         assert_eq!(addr, "168.220.85.45:8080".parse().unwrap());
@@ -268,6 +273,7 @@ mod test {
             run_id,
             auth_token,
             tls_public_certificate,
+            rwx_access_token_kind
         } = HostedQueueConfig::from_api(server.url(), &test_access_token(), &in_run_id).unwrap();
 
         assert_eq!(addr, "168.220.85.45:8080".parse().unwrap());

--- a/crates/abq_hosted/src/config.rs
+++ b/crates/abq_hosted/src/config.rs
@@ -22,11 +22,11 @@ pub struct HostedQueueConfig {
     pub rwx_access_token_kind: AccessTokenKind,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum AccessTokenKind {
-    #[serde(rename="personal_access_token")]
+    #[serde(rename = "personal_access_token")]
     Personal,
-    #[serde(rename="organization_access_token")]
+    #[serde(rename = "organization_access_token")]
     Organization,
 }
 
@@ -112,7 +112,7 @@ impl HostedQueueConfig {
             run_id: resolved_run_id,
             auth_token,
             tls_public_certificate: tls_public_certificate.map(String::into_bytes),
-            rwx_access_token_kind
+            rwx_access_token_kind,
         })
     }
 }

--- a/crates/abq_hosted/src/lib.rs
+++ b/crates/abq_hosted/src/lib.rs
@@ -6,7 +6,7 @@ mod notify;
 pub const DEFAULT_RWX_ABQ_API_URL: &str = "https://abq.build/api";
 
 pub use access_token::AccessToken;
-pub use config::HostedQueueConfig;
 pub use config::AccessTokenKind;
+pub use config::HostedQueueConfig;
 pub use error::Error as ApiError;
 pub use notify::record_test_run_metadata;

--- a/crates/abq_hosted/src/lib.rs
+++ b/crates/abq_hosted/src/lib.rs
@@ -7,5 +7,6 @@ pub const DEFAULT_RWX_ABQ_API_URL: &str = "https://abq.build/api";
 
 pub use access_token::AccessToken;
 pub use config::HostedQueueConfig;
+pub use config::AccessTokenKind;
 pub use error::Error as ApiError;
 pub use notify::record_test_run_metadata;

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -266,6 +266,7 @@ impl WorkersConfigBuilder {
             results_batch_size_hint: 1,
             protocol_version_timeout: DEFAULT_PROTOCOL_VERSION_TIMEOUT,
             test_timeout: DEFAULT_RUNNER_TEST_TIMEOUT,
+            should_send_results: true,
         };
         Self {
             config,

--- a/crates/abq_utils/src/net_protocol.rs
+++ b/crates/abq_utils/src/net_protocol.rs
@@ -83,6 +83,9 @@ pub mod entity {
         pub const fn new(workers_number: u32) -> Self {
             Self(workers_number)
         }
+        pub fn index(&self) -> u32 {
+            self.0
+        }
     }
 
     #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Debug)]

--- a/crates/abq_workers/src/negotiate.rs
+++ b/crates/abq_workers/src/negotiate.rs
@@ -228,7 +228,7 @@ impl WorkersNegotiator {
             max_run_number,
             protocol_version_timeout,
             test_timeout,
-            should_send_results
+            should_send_results,
         } = workers_config;
 
         let some_runner_should_generate_manifest = match assigned {

--- a/crates/abq_workers/src/negotiate.rs
+++ b/crates/abq_workers/src/negotiate.rs
@@ -114,6 +114,7 @@ pub struct WorkersConfig {
     pub results_batch_size_hint: u64,
     /// Max number of test suite run attempts
     pub max_run_number: u32,
+    pub should_send_results: bool,
 }
 
 #[derive(Debug, Error)]
@@ -227,6 +228,7 @@ impl WorkersNegotiator {
             max_run_number,
             protocol_version_timeout,
             test_timeout,
+            should_send_results
         } = workers_config;
 
         let some_runner_should_generate_manifest = match assigned {
@@ -244,6 +246,7 @@ impl WorkersNegotiator {
             local_results_handler,
             max_run_number,
             assigned,
+            should_send_results,
         );
 
         let pool_config = WorkerPoolConfig {
@@ -899,6 +902,7 @@ mod test {
             max_run_number: INIT_RUN_NUMBER,
             protocol_version_timeout: DEFAULT_PROTOCOL_VERSION_TIMEOUT,
             test_timeout: DEFAULT_RUNNER_TEST_TIMEOUT,
+            should_send_results: true,
         };
 
         let invoke_data = InvokeWork {

--- a/crates/abq_workers/src/results_handler.rs
+++ b/crates/abq_workers/src/results_handler.rs
@@ -16,14 +16,14 @@ use crate::test_fetching;
 
 /// A results handler that dispatches results to the remote queue, and also any local handlers.
 pub(crate) struct MultiplexingResultsHandler {
-    remote_handler: Box<dyn NotifyResults + Send>,
+    remote_handler: Option<QueueResultsSender>,
     local_handler: SharedResultsHandler,
     results_retry_tracker: test_fetching::ResultsTracker,
 }
 
 impl MultiplexingResultsHandler {
     pub fn new(
-        remote_handler: Box<dyn NotifyResults + Send>,
+        remote_handler: Option<QueueResultsSender>,
         local_handler: SharedResultsHandler,
         results_retry_tracker: test_fetching::ResultsTracker,
     ) -> Self {
@@ -40,10 +40,14 @@ impl NotifyResults for MultiplexingResultsHandler {
     #[instrument(level="trace", skip_all, fields(results=results.len()))]
     async fn send_results(&mut self, results: Vec<AssociatedTestResults>) {
         self.results_retry_tracker.account_results(results.iter());
-        let ((), ()) = tokio::join!(
-            self.remote_handler.send_results(results.clone()),
-            self.local_handler.send_results(results)
-        );
+        if let Some(remote_handler) = self.remote_handler.as_mut() {
+            let ((), ()) = tokio::join!(
+                remote_handler.send_results(results.clone()),
+                self.local_handler.send_results(results)
+            );
+        } else {
+            self.local_handler.send_results(results).await;
+        }
     }
 }
 

--- a/crates/abq_workers/src/results_handler.rs
+++ b/crates/abq_workers/src/results_handler.rs
@@ -16,14 +16,14 @@ use crate::test_fetching;
 
 /// A results handler that dispatches results to the remote queue, and also any local handlers.
 pub(crate) struct MultiplexingResultsHandler {
-    remote_handler: QueueResultsSender,
+    remote_handler: Box<dyn NotifyResults + Send>,
     local_handler: SharedResultsHandler,
     results_retry_tracker: test_fetching::ResultsTracker,
 }
 
 impl MultiplexingResultsHandler {
     pub fn new(
-        remote_handler: QueueResultsSender,
+        remote_handler: Box<dyn NotifyResults + Send>,
         local_handler: SharedResultsHandler,
         results_retry_tracker: test_fetching::ResultsTracker,
     ) -> Self {

--- a/crates/abq_workers/src/runner_strategy.rs
+++ b/crates/abq_workers/src/runner_strategy.rs
@@ -13,7 +13,7 @@ use abq_utils::{
         queue::{self, RunAlreadyCompleted},
         workers::{ManifestResult, RunId},
     },
-    results_handler::{ResultsHandler, SharedResultsHandler, NoopResultsHandler, NotifyResults},
+    results_handler::{NoopResultsHandler, NotifyResults, ResultsHandler, SharedResultsHandler},
     retry::async_retry_n,
 };
 use async_trait::async_trait;
@@ -134,7 +134,7 @@ impl StrategyGenerator for RunnerStrategyGenerator {
                     runner_entity,
                     run_id.clone(),
                 )),
-                false => Box::new(NoopResultsHandler)
+                false => Box::new(NoopResultsHandler),
             };
             let notifier = MultiplexingResultsHandler::new(
                 queue_handler,

--- a/crates/abq_workers/src/runner_strategy.rs
+++ b/crates/abq_workers/src/runner_strategy.rs
@@ -13,7 +13,7 @@ use abq_utils::{
         queue::{self, RunAlreadyCompleted},
         workers::{ManifestResult, RunId},
     },
-    results_handler::{NoopResultsHandler, NotifyResults, ResultsHandler, SharedResultsHandler},
+    results_handler::{ResultsHandler, SharedResultsHandler},
     retry::async_retry_n,
 };
 use async_trait::async_trait;
@@ -127,14 +127,14 @@ impl StrategyGenerator for RunnerStrategyGenerator {
         };
 
         let results_handler: ResultsHandler = {
-            let queue_handler: Box<dyn NotifyResults + Send> = match should_send_results {
-                true => Box::new(QueueResultsSender::new(
+            let queue_handler = match should_send_results {
+                true => Some(QueueResultsSender::new(
                     client.boxed_clone(),
                     *queue_results_addr,
                     runner_entity,
                     run_id.clone(),
                 )),
-                false => Box::new(NoopResultsHandler),
+                false => None,
             };
             let notifier = MultiplexingResultsHandler::new(
                 queue_handler,


### PR DESCRIPTION
Rwx cloud returns the type of access token used so that we can modify the behavior of the runner strategy to noop instead of sending results to the queue.

In addition, we add a new command `abq login` to store a config file at `~/.abq/config.toml`

RWX Access Tokens are sourced in the order of flag, env var, and then config file.

End users can explicitly supply the location of the config file via `ABQ_CONFIG_FILE`. By supplying a value of `""`, you opt-out of sourcing the access token from a config file (This is used mostly by our tests to avoid sourcing an access token from the host machine).

### `abq test` (w/ PAT)

![image](https://github.com/rwx-research/abq/assets/62091/d30c8d88-27b1-411f-8d15-53084dcb6820)

### `abq test` (w/ OrgAT)

![image](https://github.com/rwx-research/abq/assets/62091/185ca488-0bfe-49f6-b1c6-88696ba256a9)

### `abq login`

![image](https://github.com/rwx-research/abq/assets/62091/f25d629e-8994-49cd-af7e-d3172a03462a)

![image](https://github.com/rwx-research/abq/assets/62091/b2935fb0-0c18-4db4-b4c0-ad26b4eb067f)

## QA Plan

<details>
<summary>
1. ✅ Create test run w/ org access token, observe instruction to run locally
</summary>

```
% target/debug/abq test -n 1 --run-id tonytest2 -- bundle exec rspec bigtest/benchmark_rspec/benchmark_spec.rb
Generic test runner for tonytest2 started on worker 0a773c41-1846-4fc2-9117-d9e5ee739787 (worker 0, runner 1)
....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 19.17 seconds (files took 0.26604 seconds to load)
500 examples, 0 failures



--------------------------------------------------------------------------------
------------------------------------- ABQ --------------------------------------
--------------------------------------------------------------------------------

Finished in 20.38 seconds (18.26 seconds spent in test code)
500 tests, 0 failures


Run the following command to replay these tests locally:


        abq test --run-id tonytest2 --worker 0 --num 1


Specify your Access Token with the RWX_ACCESS_TOKEN env variable, passing --access-token, or running `abq login`.
```
</details>

<details>
<summary>
2. ✅ Run ABQ report, observe report (`target/debug/abq report --run-id tonytest2`)
</summary>

```
% target/debug/abq report --run-id tonytest2                                                        
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
....................


--------------------------------------------------------------------------------
------------------------------------- ABQ --------------------------------------
--------------------------------------------------------------------------------

Finished in 0.01 seconds (18.26 seconds spent in test code)
500 tests, 0 failures
```

</details>

<details>
<summary>
3. ✅ Run locally w/ PAT (using abq login omitted)
</summary>

```
% target/debug/abq test -n 1 --run-id tonytest2 -- bundle exec rspec bigtest/benchmark_rspec/benchmark_spec.rb
Generic test runner for tonytest2 started on worker fe09f9ad-9cb0-4ee5-90d2-438c7b8a0a58 (worker 0, runner 1)
....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 19.06 seconds (files took 0.46623 seconds to load)
500 examples, 0 failures



--------------------------------------------------------------------------------
------------------------------------- ABQ --------------------------------------
--------------------------------------------------------------------------------

Finished in 19.90 seconds (18.13 seconds spent in test code)
500 tests, 0 failures
```

</details>

<details>
<summary>
4. ✅ Run ABQ report w/ PAT, observe no retries
</summary>

```
% target/debug/abq report --run-id tonytest2                                                                  
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
....................


--------------------------------------------------------------------------------
------------------------------------- ABQ --------------------------------------
--------------------------------------------------------------------------------

Finished in 0.01 seconds (18.26 seconds spent in test code)
500 tests, 0 failures
```

</details>

<details>
<summary>
5. ✅ Run locally w/ Org Token (using abq login omitted)
</summary>

```
Generic test runner for tonytest2 started on worker 5727bad7-71ee-4c00-93b7-5feb85237b55 (worker 0, runner 1)
....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 19.13 seconds (files took 0.45984 seconds to load)
500 examples, 0 failures



--------------------------------------------------------------------------------
------------------------------------- ABQ --------------------------------------
--------------------------------------------------------------------------------

Finished in 20.05 seconds (18.18 seconds spent in test code)
500 tests, 0 failures


Run the following command to replay these tests locally:


        abq test --run-id tonytest2 --worker 0 --num 1


Specify your Access Token with the RWX_ACCESS_TOKEN env variable, passing --access-token, or running `abq login`.
```

</details>

<details>
<summary>
6. ✅ Run ABQ report w/ Org Token, observe retries
</summary>

```
% target/debug/abq report --run-id tonytest2                                                                  
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
........................................


--------------------------------------------------------------------------------
------------------------------------- ABQ --------------------------------------
--------------------------------------------------------------------------------

Finished in 0.01 seconds (36.44 seconds spent in test code)
500 tests, 0 failures, 500 retried

Retries:

    worker 0:
      500   ./bigtest/benchmark_rspec/benchmark_spec.rb
```

</details>