### PR TITLE
Permit configuring maximum number of seconds to wait for test command

### DIFF
--- a/crates/abq_cli/src/args.rs
+++ b/crates/abq_cli/src/args.rs
@@ -328,7 +328,7 @@ pub enum Command {
 
         /// The maximum number of seconds to wait for a test command to start up.
         ///
-        /// ABQ waits for the passed test command to start up before starting a test run.
+        /// ABQ waits for the test executable to start up before starting a test run.
         /// If the test command does not start up within the timeout, the test run will be cancelled.
         #[clap(long, default_value_t = abq_workers::DEFAULT_PROTOCOL_VERSION_TIMEOUT.as_secs(), env = "ABQ_STARTUP_TIMEOUT_SECONDS")]
         startup_timeout_seconds: u64,

--- a/crates/abq_cli/src/args.rs
+++ b/crates/abq_cli/src/args.rs
@@ -326,6 +326,13 @@ pub enum Command {
         #[clap(long, default_value = "auto")]
         color: ColorPreference,
 
+        /// The maximum number of seconds to wait for a test command to start up.
+        ///
+        /// ABQ waits for the passed test command to start up before starting a test run.
+        /// If the test command does not start up within the timeout, the test run will be cancelled.
+        #[clap(long, default_value_t = abq_workers::DEFAULT_PROTOCOL_VERSION_TIMEOUT.as_secs(), env = "ABQ_STARTUP_TIMEOUT_SECONDS")]
+        startup_timeout_seconds: u64,
+
         /// A broad measure of inactivity timeout seconds, after which a test run is cancelled.
         ///
         /// The inactivity timeout is applied in the following cases:

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -317,6 +317,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             tls_key,
             color,
             batch_size,
+            startup_timeout_seconds,
             inactivity_timeout_seconds,
         } => {
             let deprecations = DeprecationRecord::default();
@@ -369,6 +370,8 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
 
             let max_run_number = 1 + retries;
 
+            let startup_timeout = Duration::from_secs(startup_timeout_seconds);
+
             workers::start_workers_standalone(
                 run_id,
                 WorkerTag::new(worker as _),
@@ -382,6 +385,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
                 tests_timeout,
                 abq.negotiator_handle(),
                 abq.client_options().clone(),
+                startup_timeout,
             )
             .await
         }

--- a/crates/abq_cli/src/workers.rs
+++ b/crates/abq_cli/src/workers.rs
@@ -42,6 +42,7 @@ pub async fn start_workers_standalone(
     test_timeout: Duration,
     queue_negotiator: QueueNegotiatorHandle,
     client_opts: ClientOptions,
+    startup_timeout: Duration,
 ) -> ! {
     let test_suite_name = "suite"; // TODO: determine this correctly
     let has_stdout_reporters = reporter_kinds
@@ -68,7 +69,7 @@ pub async fn start_workers_standalone(
         worker_context: context,
         debug_native_runner: std::env::var_os("ABQ_DEBUG_NATIVE").is_some(),
         has_stdout_reporters,
-        protocol_version_timeout: abq_workers::DEFAULT_PROTOCOL_VERSION_TIMEOUT,
+        protocol_version_timeout: startup_timeout,
         test_timeout,
         results_batch_size_hint: batch_size.get(),
         max_run_number,

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -3924,7 +3924,7 @@ fn kill_on_early_startup_timeout_seconds() {
     let simulation = [
         Connect,
         //
-        Sleep(Duration::from_millis(100)),
+        Sleep(Duration::MAX),
         //
         // Write spawn message
         OpaqueWrite(pack(legal_spawned_message(proto))),
@@ -3951,6 +3951,7 @@ fn kill_on_early_startup_timeout_seconds() {
 
     let CmdOutput {
         exit_status,
+        stdout,
         stderr,
         ..
     } = Abq::new(format!("{name}_worker0"))
@@ -3959,5 +3960,10 @@ fn kill_on_early_startup_timeout_seconds() {
         .run();
 
     assert_eq!(exit_status.code().unwrap(), ExitCode::ABQ_ERROR.get());
-    assert!(stderr.contains("Timeout while waiting for protocol version"));
+    assert!(
+        stderr.contains("Timeout while waiting for protocol version"),
+        "STDOUT:\n{}\nSTDERR:\n{}\n",
+        stdout,
+        stderr
+    );
 }

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -5,6 +5,7 @@
 use abq_native_runner_simulation::{pack, pack_msgs, pack_msgs_to_disk, Msg::*};
 use abq_test_utils::{artifacts_dir, s, sanitize_output, write_to_temp, WORKSPACE};
 use abq_utils::auth::{AdminToken, UserToken};
+use abq_utils::exit::ExitCode;
 use abq_utils::net_protocol::runners::{
     AbqProtocolVersion, InitSuccessMessage, Manifest, ManifestMessage, RawTestResultMessage,
     Status, Test, TestOrGroup,
@@ -3906,4 +3907,57 @@ fn persisted_runs_between_queue_instances() {
     );
     assert_eq!(init_manifest_size, next_manifest_size);
     assert_eq!(init_run_state_size, next_run_state_size);
+}
+
+#[test]
+#[with_protocol_version]
+#[serial]
+fn kill_on_early_startup_timeout_seconds() {
+    let name = "kill_on_early_startup_timeout_seconds";
+    let conf = CSConfigOptions {
+        use_auth_token: true,
+        tls: true,
+    };
+
+    let (_queue_proc, queue_addr) = setup_queue!(name, conf);
+
+    let simulation = [
+        Connect,
+        //
+        Sleep(Duration::from_millis(100)),
+        //
+        // Write spawn message
+        OpaqueWrite(pack(legal_spawned_message(proto))),
+        //
+        // We should be killed by now
+        Exit(0),
+    ];
+
+    let packed = pack_msgs_to_disk(simulation);
+
+    let test_args = {
+        let simulator = native_runner_simulation_bin();
+        let simfile_path = packed.path.display().to_string();
+        let args = vec![
+            format!("test"),
+            format!("--queue-addr={queue_addr}"),
+            format!("--run-id=test-run-id"),
+            format!("--startup-timeout-seconds=0"),
+        ];
+        let mut args = conf.extend_args_for_client(args);
+        args.extend([s!("--"), simulator, simfile_path]);
+        args
+    };
+
+    let CmdOutput {
+        exit_status,
+        stderr,
+        ..
+    } = Abq::new(format!("{name}_worker0"))
+        .args(test_args)
+        .always_capture_stderr(true)
+        .run();
+
+    assert_eq!(exit_status.code().unwrap(), ExitCode::ABQ_ERROR.get());
+    assert!(stderr.contains("Timeout while waiting for protocol version"));
 }


### PR DESCRIPTION
Adds a `--startup-timeout-seconds` flag (and `ABQ_STARTUP_TIMEOUT_SECONDS` env var) to configure the maximum amount of time to wait for the native test process to startup.