### PR TITLE
Eagerly kill ABQ socket ports and native runner if connection fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ version = "0.1.0"
 dependencies = [
  "abq_utils",
  "regex",
+ "tempfile",
  "termcolor",
  "tokio",
  "tracing-test",

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::useless_format)]
 
 use abq_native_runner_simulation::{pack, pack_msgs, pack_msgs_to_disk, Msg::*};
-use abq_test_utils::{artifacts_dir, s, sanitize_output, WORKSPACE};
+use abq_test_utils::{artifacts_dir, s, sanitize_output, write_to_temp, WORKSPACE};
 use abq_utils::auth::{AdminToken, UserToken};
 use abq_utils::net_protocol::runners::{
     AbqProtocolVersion, InitSuccessMessage, Manifest, ManifestMessage, RawTestResultMessage,
@@ -3041,13 +3041,6 @@ fn native_runner_fault_followed_by_success_results_in_report_success() {
     }
 
     term(queue_proc);
-}
-
-fn write_to_temp(content: &str) -> NamedTempFile {
-    use std::io::Write;
-    let mut fi = NamedTempFile::new().unwrap();
-    fi.write_all(content.as_bytes()).unwrap();
-    fi
 }
 
 fn heuristic_wait_for_written_path(path: &Path) {

--- a/crates/abq_runners/generic_test_runner/src/lib.rs
+++ b/crates/abq_runners/generic_test_runner/src/lib.rs
@@ -2260,7 +2260,7 @@ mod test_init_native_runner {
     #[tokio::test]
     async fn handle_failure_of_process_that_breaks_only_when_port_dropped() {
         let js_script = write_to_temp(
-            &"
+            "
             const net = require('net');
 
             async function main() {

--- a/crates/abq_test_support/abq_test_utils/Cargo.toml
+++ b/crates/abq_test_support/abq_test_utils/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 regex.workspace = true
 tokio.workspace = true
 tracing-test.workspace = true
+tempfile.workspace = true
 termcolor.workspace = true
 abq_utils = { path = "../../abq_utils" }

--- a/crates/abq_test_support/abq_test_utils/src/lib.rs
+++ b/crates/abq_test_support/abq_test_utils/src/lib.rs
@@ -21,6 +21,7 @@ use abq_utils::{
     time::EpochMillis,
     tls::{ClientTlsStrategy, ServerTlsStrategy},
 };
+use tempfile::NamedTempFile;
 
 pub mod color_writer;
 
@@ -230,6 +231,13 @@ pub async fn build_fake_connection() -> (
         tokio::join!(client.connect(server_addr), accept_handshake(&*server));
     let (client_conn, (server_conn, _)) = (client_res.unwrap(), server_res.unwrap());
     (server, server_conn, client_conn)
+}
+
+pub fn write_to_temp(content: &str) -> NamedTempFile {
+    use std::io::Write;
+    let mut fi = NamedTempFile::new().unwrap();
+    fi.write_all(content.as_bytes()).unwrap();
+    fi
 }
 
 #[macro_export]


### PR DESCRIPTION
Prior to this patch, ABQ workers could observe the following deadlock in error paths:

- A native process NP exceeds the deadline for establishing a connection and communicating the protocol version message to an ABQ worker W.
- W the timeout hit. It stops polling for connections. However, at this point, W would keep the communication port ABQ_SOCKET alive.
- W now waits for NP to close stdout/stderr.
- At some point in the future NP connects and starts writing to ABQ_SOCKET. If the writes are very large, they get throttled due to a lack of ACKs, and NP waits for the write buffer to be flushed out.
- W is waiting for NP and NP is waiting for W, this is a deadlock.

This patch addresses the fault condition by having ABQ workers progressively degrade the quality of the environment a native process is executing in. If the connection deadline is exceeded, we now

1. Drop the ABQ_SOCKET port, making new connections or writes fault on the native process's side
2. Start a deadline based on the native protocol timeout configured for the initial connection deadline. If the deadline is exceeded before the native process has exited cleanly, we forcefully terminate the process and bail out.