### PR TITLE
move group id out of net protocol

### DIFF
--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -3191,7 +3191,6 @@ fn custom_remote_persistence() {
             {
               "run_number": 1,
               "spec": {
-                "group_id": "[redacted]",
                 "test_case": {
                   "id": "test1",
                   "meta": {}

--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -788,7 +788,11 @@ impl AllRuns {
         let batch_size = batch_size_hint;
 
         // Pop the next batch.
-        let bundle: Vec<WorkerTest> = queue.get_work(entity.tag, batch_size).cloned().collect();
+        let bundle: Vec<WorkerTest> = queue
+            .get_work(entity.tag, batch_size)
+            .cloned()
+            .map(|(spec, _)| spec)
+            .collect();
 
         let pulled_tests_status;
 
@@ -946,6 +950,7 @@ impl AllRuns {
                 let manifest: Vec<_> = queue
                     .get_partition_for_entity(entity.tag)
                     .cloned()
+                    .map(|(spec, _)| spec)
                     .collect();
                 let eow = Eow(true);
 
@@ -2738,7 +2743,6 @@ fn fake_test_spec(proto: ProtocolWitness) -> TestSpec {
     TestSpec {
         test_case: TestCase::new(proto, "fake-test", Default::default()),
         work_id: WorkId::new(),
-        group_id: GroupId::new(),
     }
 }
 
@@ -3474,7 +3478,6 @@ mod test {
                     TestSpec {
                         test_case: TestCase::new(proto, "test1", Default::default()),
                         work_id: WorkId::new(),
-                        group_id: GroupId::new(),
                     },
                     GroupId::new(),
                 )],
@@ -3565,7 +3568,6 @@ mod test {
                         TestSpec {
                             test_case: TestCase::new(proto, "test1", Default::default()),
                             work_id: WorkId::new(),
-                            group_id: GroupId::new(),
                         },
                         GroupId::new(),
                     )],

--- a/crates/abq_runners/generic_test_runner/src/lib.rs
+++ b/crates/abq_runners/generic_test_runner/src/lib.rs
@@ -1429,7 +1429,11 @@ pub fn execute_wrapped_runner(
                     }
 
                     *manifest_message = Some(real_manifest.clone());
-                    *flat_manifest = Some(real_manifest.manifest.flatten());
+                    let flattened = real_manifest.manifest.flatten();
+                    *flat_manifest = Some((
+                        flattened.0.into_iter().map(|(spec, _)| spec).collect(),
+                        flattened.1,
+                    ));
                 }
                 ManifestResult::TestRunnerError { error, output: _ } => {
                     *opt_error_cell.lock() = Some(error);

--- a/crates/abq_runners/generic_test_runner/src/lib.rs
+++ b/crates/abq_runners/generic_test_runner/src/lib.rs
@@ -969,12 +969,7 @@ async fn execute_all_tests<'a>(
         while let Some(msg) = tests_rx.recv().await {
             match msg {
                 RecvMsg::Item(WorkerTest {
-                    spec:
-                        TestSpec {
-                            test_case,
-                            work_id,
-                            group_id: _,
-                        },
+                    spec: TestSpec { test_case, work_id },
                     run_number,
                 }) => {
                     native_runner_handle
@@ -1812,8 +1807,8 @@ mod test_abq_jest {
     use abq_utils::net_protocol::runners::{AbqProtocolVersion, Status, TestCase, TestResultSpec};
     use abq_utils::net_protocol::work_server::InitContext;
     use abq_utils::net_protocol::workers::{
-        Eow, GroupId, ManifestResult, NativeTestRunnerParams, NextWorkBundle, ReportedManifest,
-        WorkId, WorkerTest, INIT_RUN_NUMBER,
+        Eow, ManifestResult, NativeTestRunnerParams, NextWorkBundle, ReportedManifest, WorkId,
+        WorkerTest, INIT_RUN_NUMBER,
     };
     use abq_utils::results_handler::{NoopResultsHandler, StaticResultsHandler};
     use abq_utils::{atomic, oneshot_notify};
@@ -2025,7 +2020,6 @@ mod test_abq_jest {
                     spec: TestSpec {
                         test_case: TestCase::new(proto, "unreachable", Default::default()),
                         work_id: WorkId::new(),
-                        group_id: GroupId::new(),
                     },
                     run_number: INIT_RUN_NUMBER,
                 }],

--- a/crates/abq_runners/generic_test_runner/tests/simulation.rs
+++ b/crates/abq_runners/generic_test_runner/tests/simulation.rs
@@ -21,7 +21,7 @@ use abq_utils::net_protocol::runners::{
 };
 use abq_utils::net_protocol::work_server::InitContext;
 use abq_utils::net_protocol::workers::{
-    Eow, GroupId, ManifestResult, NativeTestRunnerParams, NextWorkBundle, WorkId, WorkerTest,
+    Eow, ManifestResult, NativeTestRunnerParams, NextWorkBundle, WorkId, WorkerTest,
     INIT_RUN_NUMBER,
 };
 use abq_utils::oneshot_notify::OneshotTx;
@@ -289,7 +289,6 @@ fn capture_output_before_and_during_tests() {
                     spec: TestSpec {
                         test_case: TestCase::new(proto, "test1", Default::default()),
                         work_id: WorkId([1; 16]),
-                        group_id: GroupId([1; 16]),
                     },
                     run_number: INIT_RUN_NUMBER,
                 },
@@ -297,7 +296,6 @@ fn capture_output_before_and_during_tests() {
                     spec: TestSpec {
                         test_case: TestCase::new(proto, "test2", Default::default()),
                         work_id: WorkId([2; 16]),
-                        group_id: GroupId([1; 16]),
                     },
                     run_number: INIT_RUN_NUMBER,
                 },
@@ -535,7 +533,6 @@ fn native_runner_respawn_for_higher_run_numbers() {
                     spec: TestSpec {
                         test_case: TestCase::new(proto, "test1", Default::default()),
                         work_id: WorkId([1; 16]),
-                        group_id: GroupId([1; 16]),
                     },
                     run_number: INIT_RUN_NUMBER,
                 },
@@ -543,7 +540,6 @@ fn native_runner_respawn_for_higher_run_numbers() {
                     spec: TestSpec {
                         test_case: TestCase::new(proto, "test2", Default::default()),
                         work_id: WorkId([2; 16]),
-                        group_id: GroupId([1; 16]),
                     },
                     run_number: INIT_RUN_NUMBER + 1,
                 },
@@ -551,7 +547,6 @@ fn native_runner_respawn_for_higher_run_numbers() {
                     spec: TestSpec {
                         test_case: TestCase::new(proto, "test3", Default::default()),
                         work_id: WorkId([3; 16]),
-                        group_id: GroupId([1; 16]),
                     },
                     run_number: INIT_RUN_NUMBER + 2,
                 },
@@ -623,7 +618,6 @@ fn native_runner_fails_while_executing_tests() {
                     spec: TestSpec {
                         test_case: TestCase::new(proto, "test1", Default::default()),
                         work_id: WorkId([1; 16]),
-                        group_id: GroupId([1; 16]),
                     },
                     run_number: INIT_RUN_NUMBER,
                 },
@@ -631,7 +625,6 @@ fn native_runner_fails_while_executing_tests() {
                     spec: TestSpec {
                         test_case: TestCase::new(proto, "test2", Default::default()),
                         work_id: WorkId([2; 16]),
-                        group_id: GroupId([1; 16]),
                     },
                     run_number: INIT_RUN_NUMBER,
                 },
@@ -725,7 +718,6 @@ async fn cancellation_of_native_runner_succeeds() {
                 spec: TestSpec {
                     test_case: TestCase::new(proto, "test1", Default::default()),
                     work_id: WorkId([1; 16]),
-                    group_id: GroupId([1; 16]),
                 },
                 run_number: INIT_RUN_NUMBER,
             }],

--- a/crates/abq_test_support/abq_test_utils/src/lib.rs
+++ b/crates/abq_test_support/abq_test_utils/src/lib.rs
@@ -116,7 +116,6 @@ pub fn spec(id: usize) -> TestSpec {
     TestSpec {
         test_case: TestCase::new(ProtocolWitness::TEST, test(id), Default::default()),
         work_id: wid(id),
-        group_id: gid(id), // arbitrary
     }
 }
 

--- a/crates/abq_utils/src/net_protocol.rs
+++ b/crates/abq_utils/src/net_protocol.rs
@@ -493,7 +493,7 @@ pub mod queue {
         meta::DeprecationRecord,
         results::OpaqueLazyAssociatedTestResults,
         runners::{AbqProtocolVersion, NativeRunnerSpecification, TestCase, TestResult},
-        workers::{GroupId, ManifestResult, RunId, WorkId},
+        workers::{ManifestResult, RunId, WorkId},
         LARGE_MESSAGE_SIZE,
     };
     use crate::capture_output::StdioOutput;
@@ -568,8 +568,6 @@ pub mod queue {
     pub struct TestSpec {
         /// ABQ-internal identity of this test.
         pub work_id: WorkId,
-        /// ABQ-internal group identity of this test.
-        pub group_id: GroupId,
         /// The test case communicated to a native runner.
         pub test_case: TestCase,
     }

--- a/crates/abq_utils/src/net_protocol.rs
+++ b/crates/abq_utils/src/net_protocol.rs
@@ -311,7 +311,7 @@ pub mod workers {
     /// In order to do file-based allocation to workers, we need to have a way of
     /// knowing which tests are in which file. We use this group id as a proxy for that.
     /// Eventually, these groupings will be assigned to specific workers
-    #[derive(Serialize, Deserialize, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
     pub struct GroupId(pub [u8; 16]);
 
     impl GroupId {

--- a/crates/abq_utils/src/net_protocol/runners.rs
+++ b/crates/abq_utils/src/net_protocol/runners.rs
@@ -377,7 +377,6 @@ impl Manifest {
             TestSpec {
                 // Generate a fresh ID for ABQ-internal usage.
                 work_id: WorkId::new(),
-                group_id,
                 test_case: TestCase(
                     v0_2::TestCase {
                         id,
@@ -422,16 +421,13 @@ mod test_manifest {
     };
     use serde_json::Map;
 
-    fn flattened(members: Vec<TestOrGroup>) -> Vec<TestSpec> {
+    fn flattened(members: Vec<TestOrGroup>) -> Vec<(TestSpec, GroupId)> {
         Manifest {
             members,
             init_meta: Map::new(),
         }
         .flatten()
         .0
-        .into_iter()
-        .map(|(test_spec, _)| test_spec)
-        .collect()
     }
 
     fn test(name: &'static str) -> TestOrGroup {
@@ -475,7 +471,7 @@ mod test_manifest {
         let a_test = test("foo");
         let one_element_manifest = flattened(vec![a_test.clone()]);
         assert_eq!(one_element_manifest.len(), 1);
-        assert_eq!(one_element_manifest[0].test_case, to_test_case(a_test));
+        assert_eq!(one_element_manifest[0].0.test_case, to_test_case(a_test));
     }
 
     #[test]
@@ -487,7 +483,7 @@ mod test_manifest {
         let three_group_test_cases: Vec<super::TestCase> = three_group_manifest
             .clone()
             .into_iter()
-            .map(|test_spec| test_spec.test_case)
+            .map(|test_spec| test_spec.0.test_case)
             .collect();
         let expected_test_cases: Vec<super::TestCase> = vec![
             test("a"),
@@ -505,7 +501,7 @@ mod test_manifest {
 
         let three_group_groups: Vec<GroupId> = three_group_manifest
             .into_iter()
-            .map(|test_spec| test_spec.group_id)
+            .map(|test_spec| test_spec.1)
             .collect();
         assert_eq!(
             three_group_groups,

--- a/crates/abq_workers/src/negotiate.rs
+++ b/crates/abq_workers/src/negotiate.rs
@@ -615,8 +615,8 @@ mod test {
         self, InitContext, InitContextResponse, NextTestRequest, NextTestResponse,
     };
     use abq_utils::net_protocol::workers::{
-        Eow, GroupId, ManifestResult, NextWorkBundle, ReportedManifest, RunId, RunnerKind,
-        TestLikeRunner, WorkId, WorkerTest, INIT_RUN_NUMBER,
+        Eow, ManifestResult, NextWorkBundle, ReportedManifest, RunId, RunnerKind, TestLikeRunner,
+        WorkId, WorkerTest, INIT_RUN_NUMBER,
     };
     use abq_utils::results_handler::NoopResultsHandler;
     use abq_utils::server_shutdown::ShutdownManager;
@@ -663,11 +663,11 @@ mod test {
                             .0
                             .into_iter()
                             .enumerate()
-                            .map(|(i, spec)| WorkerTest {
+                            .map(|(i, (spec, group_id))| WorkerTest {
                                 spec: TestSpec {
                                     test_case: spec.test_case,
                                     work_id: WorkId([i as _; 16]),
-                                    group_id: GroupId([i as _; 16]),
+                                    group_id,
                                 },
                                 run_number: INIT_RUN_NUMBER,
                             })

--- a/crates/abq_workers/src/negotiate.rs
+++ b/crates/abq_workers/src/negotiate.rs
@@ -663,11 +663,10 @@ mod test {
                             .0
                             .into_iter()
                             .enumerate()
-                            .map(|(i, (spec, group_id))| WorkerTest {
+                            .map(|(i, (spec, ..))| WorkerTest {
                                 spec: TestSpec {
                                     test_case: spec.test_case,
                                     work_id: WorkId([i as _; 16]),
-                                    group_id,
                                 },
                                 run_number: INIT_RUN_NUMBER,
                             })

--- a/crates/abq_workers/src/test_fetching/retries.rs
+++ b/crates/abq_workers/src/test_fetching/retries.rs
@@ -357,7 +357,7 @@ pub mod test {
     use abq_utils::net_protocol::{
         queue::TestSpec,
         runners::{Status, TestCase},
-        workers::{Eow, GroupId, NextWorkBundle, WorkId, WorkerTest, INIT_RUN_NUMBER},
+        workers::{Eow, NextWorkBundle, WorkId, WorkerTest, INIT_RUN_NUMBER},
     };
     use abq_with_protocol_version::with_protocol_version;
     use rand::distributions::{Alphanumeric, DistString};
@@ -374,12 +374,10 @@ pub mod test {
         tracker.hydrate_ordered_manifest_item(TestSpec {
             test_case: TestCase::new(proto, "test1", Default::default()),
             work_id: WorkId::new(),
-            group_id: GroupId::new(),
         });
         tracker.hydrate_ordered_manifest_item(TestSpec {
             test_case: TestCase::new(proto, "test2", Default::default()),
             work_id: WorkId::new(),
-            group_id: GroupId::new(),
         });
 
         assert!(failing_subset(&tracker.entries, INIT_RUN_NUMBER)
@@ -397,17 +395,14 @@ pub mod test {
         let spec1 = TestSpec {
             test_case: TestCase::new(proto, "test1", Default::default()),
             work_id: id1,
-            group_id: GroupId::new(),
         };
         let spec2 = TestSpec {
             test_case: TestCase::new(proto, "test2", Default::default()),
             work_id: id2,
-            group_id: GroupId::new(),
         };
         let spec3 = TestSpec {
             test_case: TestCase::new(proto, "test3", Default::default()),
             work_id: id3,
-            group_id: GroupId::new(),
         };
 
         let mut tracker = RetryManifestTracker::new(INIT_RUN_NUMBER + 1);
@@ -449,27 +444,22 @@ pub mod test {
         let spec1 = TestSpec {
             test_case: TestCase::new(proto, "test1", Default::default()),
             work_id: id1,
-            group_id: GroupId::new(),
         };
         let spec2 = TestSpec {
             test_case: TestCase::new(proto, "test2", Default::default()),
             work_id: id2,
-            group_id: GroupId::new(),
         };
         let spec3 = TestSpec {
             test_case: TestCase::new(proto, "test3", Default::default()),
             work_id: id3,
-            group_id: GroupId::new(),
         };
         let spec4 = TestSpec {
             test_case: TestCase::new(proto, "test4", Default::default()),
             work_id: id4,
-            group_id: GroupId::new(),
         };
         let spec5 = TestSpec {
             test_case: TestCase::new(proto, "test5", Default::default()),
             work_id: id5,
-            group_id: GroupId::new(),
         };
 
         let mut tracker = RetryManifestTracker::new(INIT_RUN_NUMBER + 1);
@@ -521,7 +511,6 @@ pub mod test {
                     Default::default(),
                 ),
                 work_id: id,
-                group_id: GroupId::new(),
             };
             manifest.push(spec);
         }
@@ -576,17 +565,14 @@ pub mod test {
         let spec1 = TestSpec {
             test_case: TestCase::new(proto, "test1", Default::default()),
             work_id: id1,
-            group_id: GroupId::new(),
         };
         let spec2 = TestSpec {
             test_case: TestCase::new(proto, "test2", Default::default()),
             work_id: id2,
-            group_id: GroupId::new(),
         };
         let spec3 = TestSpec {
             test_case: TestCase::new(proto, "test3", Default::default()),
             work_id: id3,
-            group_id: GroupId::new(),
         };
 
         let mut tracker = RetryManifestTracker::new(INIT_RUN_NUMBER + 1);
@@ -635,17 +621,14 @@ pub mod test {
         let spec1 = TestSpec {
             test_case: TestCase::new(proto, "test1", Default::default()),
             work_id: id1,
-            group_id: GroupId::new(),
         };
         let spec2 = TestSpec {
             test_case: TestCase::new(proto, "test2", Default::default()),
             work_id: id2,
-            group_id: GroupId::new(),
         };
         let spec3 = TestSpec {
             test_case: TestCase::new(proto, "test3", Default::default()),
             work_id: id3,
-            group_id: GroupId::new(),
         };
 
         let mut tracker = RetryManifestTracker::new(INIT_RUN_NUMBER + 1);
@@ -688,17 +671,14 @@ pub mod test {
         let spec1 = TestSpec {
             test_case: TestCase::new(proto, "test1", Default::default()),
             work_id: id1,
-            group_id: GroupId::new(),
         };
         let spec2 = TestSpec {
             test_case: TestCase::new(proto, "test2", Default::default()),
             work_id: id2,
-            group_id: GroupId::new(),
         };
         let spec3 = TestSpec {
             test_case: TestCase::new(proto, "test3", Default::default()),
             work_id: id3,
-            group_id: GroupId::new(),
         };
 
         let mut tracker = RetryManifestTracker::new(INIT_RUN_NUMBER + 2);
@@ -771,17 +751,14 @@ pub mod test {
         let spec1 = TestSpec {
             test_case: TestCase::new(proto, "test1", Default::default()),
             work_id: id1,
-            group_id: GroupId::new(),
         };
         let spec2 = TestSpec {
             test_case: TestCase::new(proto, "test2", Default::default()),
             work_id: id2,
-            group_id: GroupId::new(),
         };
         let spec3 = TestSpec {
             test_case: TestCase::new(proto, "test3", Default::default()),
             work_id: id3,
-            group_id: GroupId::new(),
         };
 
         let mut tracker = RetryManifestTracker::new(INIT_RUN_NUMBER + 2);
@@ -845,12 +822,10 @@ pub mod test {
         let spec1 = TestSpec {
             test_case: TestCase::new(proto, "test1", Default::default()),
             work_id: id1,
-            group_id: GroupId::new(),
         };
         let spec2 = TestSpec {
             test_case: TestCase::new(proto, "test2", Default::default()),
             work_id: id2,
-            group_id: GroupId::new(),
         };
 
         let mut tracker = RetryManifestTracker::new(INIT_RUN_NUMBER + 2);
@@ -896,12 +871,10 @@ pub mod test {
         let spec1 = TestSpec {
             test_case: TestCase::new(proto, "test1", Default::default()),
             work_id: id1,
-            group_id: GroupId::new(),
         };
         let spec2 = TestSpec {
             test_case: TestCase::new(proto, "test2", Default::default()),
             work_id: id2,
-            group_id: GroupId::new(),
         };
 
         let mut tracker = RetryManifestTracker::new(INIT_RUN_NUMBER + 2);
@@ -965,7 +938,6 @@ pub mod test {
         let spec1 = TestSpec {
             test_case: TestCase::new(proto, "test1", Default::default()),
             work_id: id1,
-            group_id: GroupId::new(),
         };
 
         let mut tracker = RetryManifestTracker::new(INIT_RUN_NUMBER + 2);
@@ -1078,12 +1050,10 @@ pub mod test {
         let spec1 = TestSpec {
             test_case: TestCase::new(proto, "test1", Default::default()),
             work_id: id1,
-            group_id: GroupId::new(),
         };
         let spec2 = TestSpec {
             test_case: TestCase::new(proto, "test2", Default::default()),
             work_id: id2,
-            group_id: GroupId::new(),
         };
 
         let mut tracker = RetryManifestTracker::new(INIT_RUN_NUMBER + 1);

--- a/crates/abq_workers/src/workers.rs
+++ b/crates/abq_workers/src/workers.rs
@@ -656,12 +656,7 @@ async fn test_like_runner_exec_loop(
         };
 
         for WorkerTest {
-            spec:
-                TestSpec {
-                    test_case,
-                    work_id,
-                    group_id: _,
-                },
+            spec: TestSpec { test_case, work_id },
             run_number,
         } in work
         {
@@ -887,7 +882,7 @@ mod test {
     use crate::runner_strategy::{self, RunnerStrategy};
     use crate::workers::{WorkerPoolConfig, WorkersExitStatus};
     use crate::DEFAULT_RUNNER_TEST_TIMEOUT;
-    use abq_utils::net_protocol::workers::{GroupId, RunId, RunnerKind, WorkId};
+    use abq_utils::net_protocol::workers::{RunId, RunnerKind, WorkId};
 
     type ResultsCollector = Arc<Mutex<HashMap<WorkId, Vec<TestResult>>>>;
     type ManifestCollector = Arc<Mutex<Option<ManifestResult>>>;
@@ -1069,7 +1064,6 @@ mod test {
             spec: TestSpec {
                 test_case: test,
                 work_id,
-                group_id: GroupId([1; 16]),
             },
             run_number: INIT_RUN_NUMBER,
         }

--- a/crates/abq_workers/src/workers.rs
+++ b/crates/abq_workers/src/workers.rs
@@ -1083,7 +1083,15 @@ mod test {
         loop {
             let man = { manifest.lock().take() };
             match man {
-                Some(ManifestResult::Manifest(manifest)) => return manifest.manifest.flatten().0,
+                Some(ManifestResult::Manifest(manifest)) => {
+                    return manifest
+                        .manifest
+                        .flatten()
+                        .0
+                        .into_iter()
+                        .map(|(spec, _)| spec)
+                        .collect();
+                }
                 Some(ManifestResult::TestRunnerError { .. }) => unreachable!(),
                 None => {
                     tokio::time::sleep(Duration::from_micros(100)).await;


### PR DESCRIPTION
- avoid double negatives
- simplify bundle assignment
- sprinkle in some comments
- mark a bunch of private things private
- thread groupId through codebase
- extract helper for adding a test to the collection
- flatten assigns a top level group to each test
- add optional assigned groups to JobQueue
- add strategy
- group id isn't optional
- move strategy out of job queue and thread it through alongside batch size
- rename Strategy to WorkStrategy
- move WorkStrategy into net_protocol::queue
- add work_strategy to InvokeWork
- thread through to CLI
- lints
- add missing group_id
- update snaps
- some minor notes to development.md
- bring WorkStrategy to the namespace
- Update crates/abq_cli/src/args.rs
- call it test_strategy
- call it work_strategy consistently
- Update crates/abq_utils/src/net_protocol/runners.rs
- fork
- rename ByGroup to ByTopLevelGroup and stringify ByTest to `by-test`
- use the members vec directly
- drop comment
- drop comment
- typo
- Revert "use the members vec directly"
- add some manifest tests
- thread through work_strategy less
- clippy
- clippy
- drop incorrect comment
- use queue_len everywhere
- simplify clamping logic and fix a small logic bug in grouping
- store by group index correctly
- clippy
- add some comments
- add group partition tests
- fix test
- add an assertion confirming that all entities have been popped
- rename n to batch_size
- assert that every group is assigned to only one entity
- typos
- try to keep start idx valid
- clean up comments
- Update crates/abq_queue/src/job_queue.rs
- %s/WorkStrategy/TestStrategy/
- extract get_bounds functions to helpers
- end_idx can just be a mutable var
- Update crates/abq_utils/src/net_protocol.rs
- Update crates/abq_utils/src/net_protocol/runners.rs
- Update crates/abq_runners/generic_test_runner/src/lib.rs
- extract strategy strings to constants
- move comments into assertion
- nicer comments
- drop comments that are tied to implementation details
- drop comment in test module
- misc commen tweaks according to feedback
- use impl Into<
- extend and fix test
- remove printlns
- pass queue_len in
- move defensive code into branch that needs it
- add back clamping and explain how we reach every branch
- bump CI
- Allow spinning for remote manifests and results to come in
- inline batch_size_hint
- start working on integration test
- increase teset timeout
- return tuple with group id instead of putting it on the TestSpec
- remove groupId from test spec
- remove unecessary traits
- update snaps
