### PR TITLE
Correct flaky network test

### DIFF
--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -3079,6 +3079,11 @@ mod test {
             .await
             .unwrap();
 
+        // Wait for the connection to be closed by the server.
+        net_protocol::async_read::<_, ()>(&mut conn)
+            .await
+            .unwrap_err();
+
         shutdown_tx.shutdown_immediately().unwrap();
         server_task.await.unwrap().unwrap();
 


### PR DESCRIPTION
`connecting_to_work_server_with_no_auth_fails` has a client send to the
queue a request without authentication, and then checks that the queue
observes a failed connection. However, the prior implementation did not
necessarily wait for the request to be received by the server, which
could cause flakiness.
