### PR TITLE
Only record telemetry when running against remote queue

### DIFF
--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -409,7 +409,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             let abq = find_or_create_abq(
                 entity,
                 run_id.clone(),
-                queue_location,
+                queue_location.clone(),
                 resolved_token,
                 client_auth,
                 resolved_tls,
@@ -438,11 +438,12 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
 
             let startup_timeout = Duration::from_secs(startup_timeout_seconds);
 
-            let test_run_metadata = access_token.map(|token| TestRunMetadata {
+            let test_run_metadata = TestRunMetadata {
                 api_url: get_hosted_api_base_url(),
-                access_token: token,
+                access_token,
                 run_id: run_id.clone(),
-            });
+                record_telemetry: queue_location.is_remote(),
+            };
 
             workers::start_workers_standalone(
                 run_id,
@@ -620,6 +621,7 @@ struct ResolvedConfig {
     queue_location: QueueLocation,
 }
 
+#[derive(Clone)]
 enum QueueLocation {
     Remote(SocketAddr),
     Ephemeral { opt_tls_key: Option<Vec<u8>> },

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -4468,3 +4468,105 @@ fn test_run_telemetry_enabled() {
 
     term(queue_proc);
 }
+
+#[test]
+#[with_protocol_version]
+#[serial]
+fn test_run_telemetry_only_enabled_for_remote_queues() {
+    let name = "test_run_telemetry_only_enabled_for_remote_queues";
+    let conf = CSConfigOptions {
+        use_auth_token: true,
+        tls: true,
+    };
+    let (queue_proc, ..) = setup_queue!(name, conf);
+    let manifest = vec![TestOrGroup::test(Test::new(
+        proto,
+        "some_test",
+        [],
+        Default::default(),
+    ))];
+    let proto = AbqProtocolVersion::V0_2.get_supported_witness().unwrap();
+    let manifest = ManifestMessage::new(Manifest::new(manifest, Default::default()));
+
+    let access_token = test_access_token();
+
+    {
+        let mut server = Server::new();
+        let record_test_run_mock = server
+            .mock("POST", "/record_test_run")
+            .match_header("Authorization", format!("Bearer {}", access_token).as_str())
+            .match_header("User-Agent", format!("abq/{}", abq_utils::VERSION).as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json!({}).to_string())
+            .expect(0)
+            .create();
+
+        let simulation = [
+            Connect,
+            //
+            // Write spawn message
+            OpaqueWrite(pack(legal_spawned_message(proto))),
+            //
+            // Write the manifest if we need to.
+            // Otherwise handle the one test.
+            IfGenerateManifest {
+                then_do: vec![OpaqueWrite(pack(&manifest))],
+                else_do: {
+                    let mut run_tests = vec![
+                        //
+                        // Read init context message + write ACK
+                        OpaqueRead,
+                        OpaqueWrite(pack(InitSuccessMessage::new(proto))),
+                    ];
+
+                    // If the socket is alive (i.e. we have a test to run), pull it and give back a
+                    // faux result.
+                    // Otherwise assume we ran out of tests on our node and exit.
+                    run_tests.push(IfAliveReadAndWriteFake(Status::Success));
+                    run_tests
+                },
+            },
+            //
+            // Finish
+            Exit(0),
+        ];
+
+        let packed = pack_msgs_to_disk(simulation);
+
+        let test_args = {
+            let simulator = native_runner_simulation_bin();
+            let simfile_path = packed.path.display().to_string();
+            let args = vec![
+                format!("test"),
+                format!("--worker=1"),
+                format!("-n=1"),
+                format!("--tls-key={}", TLS_KEY),
+            ];
+            let mut args = conf.extend_args_for_client(args);
+            args.extend([s!("--"), simulator, simfile_path]);
+            args
+        };
+
+        let CmdOutput {
+            exit_status,
+            stderr,
+            stdout,
+        } = Abq::new(format!("{name}_initial"))
+            .args(test_args)
+            .env([("ABQ_API", server.url())])
+            .run();
+
+        assert!(
+            exit_status.success(),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+        assert!(
+            stdout.contains("1 tests, 0 failures"),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+        record_test_run_mock.assert();
+    }
+
+    term(queue_proc);
+}

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -2908,7 +2908,6 @@ fn report_while_run_in_progress_is_error() {
 #[test]
 #[with_protocol_version]
 #[serial]
-#[ignore]
 fn test_explicit_run_id_against_ephemeral_queue() {
     let name = "test_explicit_run_id_against_ephemeral_queue";
     let args = vec![
@@ -2938,7 +2937,6 @@ fn test_explicit_run_id_against_ephemeral_queue() {
 #[test]
 #[with_protocol_version]
 #[serial]
-#[ignore]
 fn report_explicit_run_id_against_ephemeral_queue() {
     let name = "report_explicit_run_id_against_ephemeral_queue";
     let args = vec![

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -2908,6 +2908,7 @@ fn report_while_run_in_progress_is_error() {
 #[test]
 #[with_protocol_version]
 #[serial]
+#[ignore]
 fn test_explicit_run_id_against_ephemeral_queue() {
     let name = "test_explicit_run_id_against_ephemeral_queue";
     let args = vec![
@@ -2937,6 +2938,7 @@ fn test_explicit_run_id_against_ephemeral_queue() {
 #[test]
 #[with_protocol_version]
 #[serial]
+#[ignore]
 fn report_explicit_run_id_against_ephemeral_queue() {
     let name = "report_explicit_run_id_against_ephemeral_queue";
     let args = vec![

--- a/crates/abq_runners/generic_test_runner/tests/simulation.rs
+++ b/crates/abq_runners/generic_test_runner/tests/simulation.rs
@@ -583,6 +583,7 @@ fn native_runner_respawn_for_higher_run_numbers() {
 
 #[test]
 #[with_protocol_version]
+#[ignore]
 fn native_runner_fails_while_executing_tests() {
     use Msg::*;
 

--- a/crates/abq_runners/generic_test_runner/tests/simulation.rs
+++ b/crates/abq_runners/generic_test_runner/tests/simulation.rs
@@ -583,7 +583,6 @@ fn native_runner_respawn_for_higher_run_numbers() {
 
 #[test]
 #[with_protocol_version]
-#[ignore]
 fn native_runner_fails_while_executing_tests() {
     use Msg::*;
 


### PR DESCRIPTION
Noticed this when doing some QA for https://github.com/rwx-research/abq/pull/52

I made a bad assumption that we were recorded telemetry for all test runs. As it turns out we were only doing so when running against a remote queue (which in hindsight, seems obvious, but I was influenced by some other conversations that led me to think otherwise).

Anyway, this modifies the code such that we will only record telemetry when we've detected we are in fact running against a remote queue.

I've simulated this in an integration test by forcing an ephemeral queue in an integration test and observing no call to record test run was made.

