### PR TITLE
Lower the log level of failed connections

### DIFF
--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -1774,7 +1774,7 @@ impl QueueServer {
                     match conn {
                         Ok((conn, _)) => HandleConn(conn),
                         Err(e) => {
-                            tracing::error!("error accepting connection to queue: {:?}", e);
+                            tracing::warn!("error accepting connection to queue: {:?}", e);
                             continue;
                         }
                     }
@@ -1793,7 +1793,7 @@ impl QueueServer {
                     tokio::spawn(async move {
                         let result = Self::handle(ctx, client).await;
                         if let Err(error) = result {
-                            log_entityful_error!(error, "error handling connection to queue: {}")
+                            log_entityful!(warn, error, "error handling connection to queue: {}")
                         }
                     });
                 }

--- a/crates/abq_utils/src/error.rs
+++ b/crates/abq_utils/src/error.rs
@@ -119,7 +119,16 @@ pub use crate::log_entityful_error;
 
 #[macro_export]
 macro_rules! log_entityful_error {
-    ($err:expr, $($field:tt)*) => {{
+    ($err:expr, $($field:tt)*) => {
+        $crate::log_entityful!(error, $err, $($field)*);
+    };
+}
+
+pub use crate::log_entityful;
+
+#[macro_export]
+macro_rules! log_entityful {
+    ($level:ident, $err:expr, $($field:tt)*) => {{
         let $crate::error::EntityfulError {
             error:
                 $crate::error::LocatedError {
@@ -130,7 +139,7 @@ macro_rules! log_entityful_error {
         } = $err;
         match entity {
             Some(entity) => {
-                tracing::error!(
+                tracing::$level!(
                     entity_id=%entity.display_id(),
                     entity_tag=%entity.tag,
                     file,
@@ -141,7 +150,7 @@ macro_rules! log_entityful_error {
                 );
             }
             None => {
-                tracing::error!(
+                tracing::$level!(
                     entity_id="<unknown>",
                     entity_tag="<unknown>",
                     file,

--- a/crates/abq_workers/src/negotiate.rs
+++ b/crates/abq_workers/src/negotiate.rs
@@ -23,7 +23,7 @@ use abq_utils::{
     auth::User,
     error::{EntityfulError, ErrorEntity, ResultLocation},
     exit::ExitCode,
-    here, log_entityful_error, net, net_async,
+    here, log_entityful, net, net_async,
     net_opt::ClientOptions,
     net_protocol::{
         self,
@@ -470,7 +470,7 @@ impl QueueNegotiator {
                         match conn {
                             Ok(conn) => conn,
                             Err(e) => {
-                                tracing::error!("error accepting connection to negotiator: {:?}", e);
+                                tracing::warn!("error accepting connection to negotiator: {:?}", e);
                                 continue;
                             }
                         }
@@ -485,7 +485,8 @@ impl QueueNegotiator {
                     async move {
                         let result = Self::handle_conn(ctx, client).await;
                         if let Err(error) = result {
-                            log_entityful_error!(
+                            log_entityful!(
+                                warn,
                                 error,
                                 "error handling connection to negotiator: {:?}"
                             );


### PR DESCRIPTION
These are filled with messages like "received corrupted message of type
Handshake", which signify failures in the TLS connection, likely from
aborted or immaterial requests. They cover up more material errors, so
lower their level.
