### PR TITLE
Stream test results without batched loads into server memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.2
+
+ABQ 1.6.2 is a patch release fixing an issue that could result in
+denial-of-service of an ABQ queue due to large test results.
+
 ## 1.6.1
 
 ABQ 1.6.1 is a patch release fixing an issue that would not continue offloading

--- a/crates/abq_queue/src/persistence/results.rs
+++ b/crates/abq_queue/src/persistence/results.rs
@@ -157,7 +157,7 @@ impl ResultsPersistedCell {
         }
     }
 
-    pub fn eligible_to_retreive(&self) -> bool {
+    pub fn eligible_to_retrieve(&self) -> bool {
         self.0.processing.load(atomic::ORDERING) == 0
     }
 
@@ -233,7 +233,7 @@ mod test {
         let cell = ResultsPersistedCell::new(RunId::unique());
         cell.0.processing.fetch_add(1, atomic::ORDERING);
 
-        assert!(!cell.eligible_to_retreive());
+        assert!(!cell.eligible_to_retrieve());
     }
 
     #[tokio::test]
@@ -288,7 +288,7 @@ mod test {
         // That's okay. But the retrieved must definitely include at least results1.
         let retrieve_task = {
             async {
-                while !cell.eligible_to_retreive() {
+                while !cell.eligible_to_retrieve() {
                     tokio::time::sleep(Duration::from_micros(1)).await;
                 }
 

--- a/crates/abq_queue/src/persistence/results.rs
+++ b/crates/abq_queue/src/persistence/results.rs
@@ -2,6 +2,8 @@
 
 mod fs;
 mod in_memory;
+#[cfg(test)]
+pub(crate) mod test_utils;
 
 pub use fs::FilesystemPersistor;
 pub use in_memory::InMemoryPersistor;
@@ -13,13 +15,28 @@ use abq_utils::{
     error::LocatedError,
     net_protocol::{
         queue::AssociatedTestResults,
-        results::{OpaqueLazyAssociatedTestResults, ResultsLine, Summary},
+        results::{ResultsLine, Summary},
         workers::RunId,
     },
 };
 use async_trait::async_trait;
 
 type Result<T> = std::result::Result<T, LocatedError>;
+
+pub type OpaqueAsyncReader<'a> = dyn tokio::io::AsyncRead + Send + Unpin + 'a;
+
+pub struct ResultsStream<'a> {
+    pub stream: Box<&'a mut OpaqueAsyncReader<'a>>,
+    pub len: usize,
+}
+
+#[async_trait]
+pub trait WithResultsStream {
+    async fn with_results_stream<'a>(
+        self: Box<Self>,
+        results_stream: ResultsStream<'a>,
+    ) -> Result<()>;
+}
 
 #[async_trait]
 pub trait PersistResults: Send + Sync {
@@ -29,8 +46,12 @@ pub trait PersistResults: Send + Sync {
     /// Dumps the persisted results to a remote, if any is configured.
     async fn dump_to_remote(&self, run_id: &RunId) -> Result<()>;
 
-    /// Load a set of test results as [OpaqueLazyAssociatedTestResults].
-    async fn get_results(&self, run_id: &RunId) -> Result<OpaqueLazyAssociatedTestResults>;
+    /// Execute a closure with access to a stream of raw bytes interpretable as [OpaqueLazyAssociatedTestResults].
+    async fn with_results_stream(
+        &self,
+        run_id: &RunId,
+        f: Box<dyn WithResultsStream + Send>,
+    ) -> Result<()>;
 
     fn boxed_clone(&self) -> Box<dyn PersistResults>;
 }
@@ -136,16 +157,21 @@ impl ResultsPersistedCell {
         }
     }
 
+    pub fn eligible_to_retreive(&self) -> bool {
+        self.0.processing.load(atomic::ORDERING) == 0
+    }
+
     /// Attempts to retrieve a set of test results.
     /// If there are persistence jobs pending, returns [None].
-    pub async fn retrieve(
+    pub async fn retrieve_with_callback(
         &self,
         persistence: &SharedPersistResults,
-    ) -> Option<Result<OpaqueLazyAssociatedTestResults>> {
-        if self.0.processing.load(atomic::ORDERING) != 0 {
-            return None;
-        }
-        Some(persistence.0.get_results(&self.0.run_id).await)
+        callback: Box<dyn WithResultsStream + Send>,
+    ) -> Result<()> {
+        persistence
+            .0
+            .with_results_stream(&self.0.run_id, callback)
+            .await
     }
 }
 
@@ -197,20 +223,17 @@ mod test {
 
     use crate::persistence::{
         remote::{self, fake_error, PersistenceKind},
-        results::EligibleForRemoteDump,
+        results::{test_utils::retrieve_results, EligibleForRemoteDump},
     };
 
     use super::{fs::FilesystemPersistor, ResultsPersistedCell};
 
     #[tokio::test]
-    async fn retrieve_is_none_while_pending() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let persistence = FilesystemPersistor::new_shared(tempdir.path(), 1, remote::NoopPersister);
-
+    async fn not_eligible_to_retrieve_while_there_are_pending_results() {
         let cell = ResultsPersistedCell::new(RunId::unique());
         cell.0.processing.fetch_add(1, atomic::ORDERING);
 
-        assert!(cell.retrieve(&persistence).await.is_none());
+        assert!(!cell.eligible_to_retreive());
     }
 
     #[tokio::test]
@@ -232,8 +255,8 @@ mod test {
 
         let cell = ResultsPersistedCell::new(RunId::unique());
 
-        let retrieved = cell.retrieve(&persistence).await.unwrap().unwrap();
-        let results = retrieved.decode().unwrap();
+        let results = retrieve_results(&cell, &persistence).await.unwrap();
+        let results = results.decode().unwrap();
         assert!(results.is_empty());
     }
 
@@ -265,12 +288,11 @@ mod test {
         // That's okay. But the retrieved must definitely include at least results1.
         let retrieve_task = {
             async {
-                loop {
-                    match cell.retrieve(&persistence).await {
-                        None => tokio::time::sleep(Duration::from_micros(1)).await,
-                        Some(results) => break results,
-                    }
+                while !cell.eligible_to_retreive() {
+                    tokio::time::sleep(Duration::from_micros(1)).await;
                 }
+
+                retrieve_results(&cell, &persistence).await
             }
         };
         let persist_task = async {
@@ -283,8 +305,7 @@ mod test {
         };
         let ((), retrieve_result) = tokio::join!(persist_task, retrieve_task);
 
-        let retrieved = retrieve_result.unwrap();
-        let results = retrieved.decode().unwrap();
+        let results = retrieve_result.unwrap().decode().unwrap();
 
         use ResultsLine::Results;
         match results.len() {

--- a/crates/abq_queue/src/persistence/results/test_utils.rs
+++ b/crates/abq_queue/src/persistence/results/test_utils.rs
@@ -1,0 +1,63 @@
+#![cfg(test)]
+
+use std::sync::Arc;
+
+use abq_utils::{
+    error::{ErrorLocation, OpaqueResult, ResultLocation},
+    here,
+    net_protocol::results::OpaqueLazyAssociatedTestResults,
+};
+use async_trait::async_trait;
+use parking_lot::Mutex;
+
+use super::{ResultsPersistedCell, ResultsStream, SharedPersistResults, WithResultsStream};
+
+#[derive(Default, Clone)]
+pub struct ResultsWrapper(Arc<Mutex<Option<OpaqueLazyAssociatedTestResults>>>);
+
+impl ResultsWrapper {
+    pub fn get(self) -> OpaqueResult<OpaqueLazyAssociatedTestResults> {
+        let mut guard = self.0.lock();
+        guard
+            .take()
+            .ok_or_else(|| "Results already taken".located(here!()))
+    }
+}
+
+pub struct ResultsLoader {
+    pub results: ResultsWrapper,
+}
+
+#[async_trait]
+impl WithResultsStream for ResultsLoader {
+    async fn with_results_stream<'a>(
+        self: Box<Self>,
+        results_stream: ResultsStream<'a>,
+    ) -> super::Result<()> {
+        let ResultsStream { mut stream, len: _ } = results_stream;
+
+        let loaded = OpaqueLazyAssociatedTestResults::read_results_lines(&mut stream)
+            .await
+            .located(here!())?;
+
+        *self.results.0.lock() = Some(loaded);
+
+        Ok(())
+    }
+}
+
+pub async fn retrieve_results(
+    cell: &ResultsPersistedCell,
+    persistence: &SharedPersistResults,
+) -> OpaqueResult<OpaqueLazyAssociatedTestResults> {
+    let results = ResultsWrapper::default();
+    let results_loader = ResultsLoader {
+        results: results.clone(),
+    };
+
+    cell.retrieve_with_callback(persistence, Box::new(results_loader))
+        .await
+        .located(here!())?;
+
+    results.get()
+}

--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -28,7 +28,7 @@ use abq_utils::net_protocol::{
     queue::{InvokeWork, Message, RunStatus},
     workers::RunId,
 };
-use abq_utils::net_protocol::{meta, publicize_addr};
+use abq_utils::net_protocol::{async_write_stream, meta, publicize_addr};
 use abq_utils::server_shutdown::{ShutdownManager, ShutdownReceiver};
 use abq_utils::tls::ServerTlsStrategy;
 use abq_utils::vec_map::VecMap;
@@ -49,7 +49,8 @@ use crate::persistence::manifest::{
 };
 use crate::persistence::remote::{LoadedRunState, RemotePersister};
 use crate::persistence::results::{
-    EligibleForRemoteDump, ResultsPersistedCell, SharedPersistResults,
+    EligibleForRemoteDump, ResultsPersistedCell, ResultsStream, SharedPersistResults,
+    WithResultsStream,
 };
 use crate::persistence::run_state::PersistRunStatePlan;
 use crate::timeout::{FiredTimeout, RunTimeoutManager, RunTimeoutStrategy, TimeoutReason};
@@ -2243,80 +2244,49 @@ impl QueueServer {
         entity: Entity,
         mut stream: Box<dyn net_async::ServerStream>,
     ) -> OpaqueResult<()> {
-        let response;
-        let result;
-
         enum Response {
             One(TestResultsResponse),
             Chunk(OpaqueLazyAssociatedTestResults),
         }
-        use Response::*;
-
-        match queues.get_read_results_cell(&run_id).located(here!()) {
+        let results_cell = match queues.get_read_results_cell(&run_id).located(here!()) {
             Ok(state) => match state {
-                ReadResultsState::ReadFromCell(cell) => {
-                    // Happy path: actually attempt the retrieval. Let's see what comes up.
-                    match cell.retrieve(&persist_results).await {
-                        Some(Ok(results)) => {
-                            response = Chunk(results);
-                            result = Ok(());
-                        }
-                        None => {
-                            response = One(TestResultsResponse::Pending);
-                            result = Ok(());
-                        }
-                        Some(Err(e)) => {
-                            response = One(TestResultsResponse::Error(e.to_string()));
-                            result = Err(e.error.to_string().located(here!()));
-                        }
-                    };
-                }
+                ReadResultsState::ReadFromCell(cell) => cell,
                 ReadResultsState::OutstandingRunners(tags) => {
-                    response = One(TestResultsResponse::OutstandingRunners(tags));
-                    result = Ok(());
-                }
-            },
-            Err(e) => {
-                response = One(TestResultsResponse::Error(e.error.to_string()));
-                result = Err(e);
-            }
-        };
+                    let response = TestResultsResponse::OutstandingRunners(tags);
 
-        match response {
-            One(response) => {
-                net_protocol::async_write(&mut stream, &response)
-                    .await
-                    .located(here!())?;
-            }
-            Chunk(results) => {
-                // Split the results into chunks that will fit in individual messages over the
-                // network.
-                //
-                // Chunking is CPU-bound and typically quite fast if there are no chunks,
-                // but might eat allocations if there is indeed material chunking to do.
-                // Since this is usually run by a client after the critical section of a test run,
-                // move it to a dedicated CPU region to avoid starving the main queue responder
-                // threads.
-                let chunks = tokio::task::spawn_blocking(|| {
-                    TestResultsResponse::chunk_results(results).located(here!())
-                })
-                .await
-                .located(here!())??;
-
-                let mut iter = chunks.into_iter().peekable();
-                while let Some(chunk) = iter.next() {
-                    let response = TestResultsResponse::Results {
-                        chunk,
-                        final_chunk: iter.peek().is_none(),
-                    };
                     net_protocol::async_write(&mut stream, &response)
                         .await
                         .located(here!())?;
+
+                    return Ok(());
                 }
+            },
+            Err(e) => {
+                let response = TestResultsResponse::Error(e.error.to_string());
+
+                net_protocol::async_write(&mut stream, &response)
+                    .await
+                    .located(here!())?;
+
+                return Err(e);
             }
+        };
+
+        if !results_cell.eligible_to_retreive() {
+            net_protocol::async_write(&mut stream, &TestResultsResponse::Pending)
+                .await
+                .located(here!())?;
+
+            return Ok(());
         }
 
-        result
+        let stream_results_callback = StreamResultsCallback {
+            client_stream: stream,
+        };
+
+        results_cell
+            .retrieve_with_callback(&persist_results, Box::new(stream_results_callback))
+            .await
     }
 
     #[instrument(level = "trace", skip(queues))]
@@ -2415,6 +2385,42 @@ impl QueueServer {
                 Ok(())
             }
         }
+    }
+}
+
+struct StreamResultsCallback {
+    client_stream: Box<dyn net_async::ServerStream>,
+}
+
+#[async_trait]
+impl WithResultsStream for StreamResultsCallback {
+    async fn with_results_stream<'a>(
+        mut self: Box<Self>,
+        results_stream: ResultsStream<'a>,
+    ) -> OpaqueResult<()> {
+        let ResultsStream {
+            stream: mut results_stream,
+            len: results_len,
+        } = results_stream;
+
+        // Indicate the client that we are about to stream all JSON lines.
+        net_protocol::async_write(
+            &mut self.client_stream,
+            &TestResultsResponse::StreamingResults,
+        )
+        .await
+        .located(here!())?;
+
+        // Stream the entire json lines.
+        async_write_stream(
+            &mut self.client_stream,
+            results_len as _,
+            &mut results_stream,
+        )
+        .await
+        .located(here!())?;
+
+        Ok(())
     }
 }
 
@@ -4580,7 +4586,7 @@ mod persist_results {
             self,
             entity::{Entity, Tag},
             queue::{AssociatedTestResults, CancelReason, TestResultsResponse, TestStrategy},
-            results::ResultsLine,
+            results::{OpaqueLazyAssociatedTestResults, ResultsLine},
             runners::TestResult,
             workers::RunId,
         },
@@ -4589,6 +4595,7 @@ mod persist_results {
 
     use crate::{
         job_queue::JobQueue,
+        persistence::results::test_utils::retrieve_results,
         persistence::{self, results::ResultsPersistedCell},
         queue::ReadResultsState,
         worker_tracking::WorkerSet,
@@ -4636,9 +4643,12 @@ mod persist_results {
         .await
         .unwrap();
 
-        let opt_retrieved = results_cell.retrieve(&results_persistence).await;
-        assert!(opt_retrieved.is_some(), "outstanding pending results");
-        let actual_results = opt_retrieved.unwrap().unwrap().decode().unwrap();
+        assert!(
+            results_cell.eligible_to_retreive(),
+            "outstanding pending results"
+        );
+        let retrieved = retrieve_results(&results_cell, &results_persistence).await;
+        let actual_results = retrieved.unwrap().decode().unwrap();
         assert_eq!(actual_results, vec![ResultsLine::Results(results)]);
     }
 
@@ -4679,9 +4689,12 @@ mod persist_results {
         .await
         .unwrap();
 
-        let opt_retrieved = results_cell.retrieve(&results_persistence).await;
-        assert!(opt_retrieved.is_some(), "outstanding pending results");
-        let actual_results = opt_retrieved.unwrap().unwrap().decode().unwrap();
+        assert!(
+            results_cell.eligible_to_retreive(),
+            "outstanding pending results"
+        );
+        let retrieved = retrieve_results(&results_cell, &results_persistence).await;
+        let actual_results = retrieved.unwrap().decode().unwrap();
         assert_eq!(actual_results, vec![ResultsLine::Results(results)]);
     }
 
@@ -4719,10 +4732,13 @@ mod persist_results {
 
         assert!(result.is_err());
 
-        let opt_retrieved = results_cell.retrieve(&results_persistence).await;
-        assert!(opt_retrieved.is_some(), "outstanding pending results");
         assert!(
-            opt_retrieved.unwrap().is_err(),
+            results_cell.eligible_to_retreive(),
+            "outstanding pending results"
+        );
+        let retrieved = retrieve_results(&results_cell, &results_persistence).await;
+        assert!(
+            retrieved.is_err(),
             "cancelled run before any results has results associated"
         );
     }
@@ -4907,14 +4923,17 @@ mod persist_results {
                     };
 
                     let read_results_fut = async move {
-                        net_protocol::async_read::<_, TestResultsResponse>(&mut client_conn)
-                            .await
-                            .unwrap()
+                        let response =
+                            net_protocol::async_read::<_, TestResultsResponse>(&mut client_conn)
+                                .await
+                                .unwrap();
+                        (response, client_conn)
                     };
 
-                    let ((), response) = tokio::join!(fetch_results_fut, read_results_fut);
+                    let ((), (response, client_conn)) =
+                        tokio::join!(fetch_results_fut, read_results_fut);
 
-                    response
+                    (response, client_conn)
                 }
             }
         };
@@ -4927,12 +4946,13 @@ mod persist_results {
                 ResultsLine::Results(results1.clone()),
                 ResultsLine::Results(results2.clone()),
             ];
-            let response = get_test_results_response().await;
+            let (response, mut conn) = get_test_results_response().await;
             match response {
-                Results {
-                    chunk: results,
-                    final_chunk: true,
-                } => {
+                StreamingResults => {
+                    let results = OpaqueLazyAssociatedTestResults::read_results_lines(&mut conn)
+                        .await
+                        .unwrap();
+
                     let results = results.decode().unwrap();
                     assert_eq!(results, expected_results);
                 }
@@ -4948,7 +4968,7 @@ mod persist_results {
                 matches!(retry_manifest, RetryManifestState::FetchFromPersistence),
                 "{retry_manifest:?}"
             );
-            let response = get_test_results_response().await;
+            let (response, _conn) = get_test_results_response().await;
             match response {
                 OutstandingRunners(tags) => {
                     assert_eq!(tags, vec![Tag::runner(1, 1)]);
@@ -4985,12 +5005,13 @@ mod persist_results {
                 ResultsLine::Results(results2),
                 ResultsLine::Results(results3),
             ];
-            let response = get_test_results_response().await;
+            let (response, mut conn) = get_test_results_response().await;
             match response {
-                Results {
-                    chunk: results,
-                    final_chunk: true,
-                } => {
+                StreamingResults => {
+                    let results = OpaqueLazyAssociatedTestResults::read_results_lines(&mut conn)
+                        .await
+                        .unwrap();
+
                     let results = results.decode().unwrap();
                     assert_eq!(results, expected_results);
                 }

--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -2272,7 +2272,7 @@ impl QueueServer {
             }
         };
 
-        if !results_cell.eligible_to_retreive() {
+        if !results_cell.eligible_to_retrieve() {
             net_protocol::async_write(&mut stream, &TestResultsResponse::Pending)
                 .await
                 .located(here!())?;
@@ -4644,7 +4644,7 @@ mod persist_results {
         .unwrap();
 
         assert!(
-            results_cell.eligible_to_retreive(),
+            results_cell.eligible_to_retrieve(),
             "outstanding pending results"
         );
         let retrieved = retrieve_results(&results_cell, &results_persistence).await;
@@ -4690,7 +4690,7 @@ mod persist_results {
         .unwrap();
 
         assert!(
-            results_cell.eligible_to_retreive(),
+            results_cell.eligible_to_retrieve(),
             "outstanding pending results"
         );
         let retrieved = retrieve_results(&results_cell, &results_persistence).await;
@@ -4733,7 +4733,7 @@ mod persist_results {
         assert!(result.is_err());
 
         assert!(
-            results_cell.eligible_to_retreive(),
+            results_cell.eligible_to_retrieve(),
             "outstanding pending results"
         );
         let retrieved = retrieve_results(&results_cell, &results_persistence).await;

--- a/crates/abq_queue/src/queue.rs
+++ b/crates/abq_queue/src/queue.rs
@@ -4949,7 +4949,8 @@ mod persist_results {
             let (response, mut conn) = get_test_results_response().await;
             match response {
                 StreamingResults => {
-                    let results = OpaqueLazyAssociatedTestResults::read_results_lines(&mut conn)
+                    let mut stream = net_protocol::async_read_stream(&mut conn).await.unwrap();
+                    let results = OpaqueLazyAssociatedTestResults::read_results_lines(&mut stream)
                         .await
                         .unwrap();
 
@@ -5008,7 +5009,8 @@ mod persist_results {
             let (response, mut conn) = get_test_results_response().await;
             match response {
                 StreamingResults => {
-                    let results = OpaqueLazyAssociatedTestResults::read_results_lines(&mut conn)
+                    let mut stream = net_protocol::async_read_stream(&mut conn).await.unwrap();
+                    let results = OpaqueLazyAssociatedTestResults::read_results_lines(&mut stream)
                         .await
                         .unwrap();
 

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -716,8 +716,10 @@ async fn run_test(server: Server, steps: Steps<'_>) {
                     use TestResultsResponse::*;
                     let outcome = match response {
                         StreamingResults => {
+                            let mut stream =
+                                net_protocol::async_read_stream(&mut conn).await.unwrap();
                             let results =
-                                OpaqueLazyAssociatedTestResults::read_results_lines(&mut conn)
+                                OpaqueLazyAssociatedTestResults::read_results_lines(&mut stream)
                                     .await
                                     .unwrap();
                             TestResultsOutcome::Results(results)

--- a/crates/abq_utils/src/net_protocol.rs
+++ b/crates/abq_utils/src/net_protocol.rs
@@ -458,17 +458,15 @@ pub mod workers {
 }
 
 pub mod queue {
-    use std::{fmt::Display, io, net::SocketAddr, num::NonZeroU64, str::FromStr};
+    use std::{fmt::Display, net::SocketAddr, num::NonZeroU64, str::FromStr};
 
     use serde_derive::{Deserialize, Serialize};
 
     use super::{
         entity::{Entity, Tag},
         meta::DeprecationRecord,
-        results::OpaqueLazyAssociatedTestResults,
         runners::{AbqProtocolVersion, NativeRunnerSpecification, TestCase, TestResult},
         workers::{ManifestResult, RunId, WorkId},
-        LARGE_MESSAGE_SIZE,
     };
     use crate::capture_output::StdioOutput;
 
@@ -671,13 +669,9 @@ pub mod queue {
 
     #[derive(Serialize, Deserialize, Debug)]
     pub enum TestResultsResponse {
-        /// The test results are available.
-        Results {
-            /// A slice of test results.
-            /// May be split off the full list to avoid exceeding the maximum network message size.
-            chunk: OpaqueLazyAssociatedTestResults,
-            final_chunk: bool,
-        },
+        /// The test results will be streamed, and should be decoded as
+        /// [OpaqueLazyAssociatedTestResults::read_results_lines].
+        StreamingResults,
         /// Some test results are still being persisted, the request for test results should
         /// re-query in the future.
         Pending,
@@ -685,20 +679,6 @@ pub mod queue {
         OutstandingRunners(Vec<Tag>),
         /// The test results are unavailable for the given reason.
         Error(String),
-    }
-
-    impl TestResultsResponse {
-        const MAX_OVERHEAD_OF_RESPONSE_FOR_RESULTS: usize = 50;
-
-        /// Splits [OpaqueLazyAssociatedTestResults] into network-safe chunks ready for wrapping by
-        /// this response type.
-        pub fn chunk_results(
-            results: OpaqueLazyAssociatedTestResults,
-        ) -> io::Result<Vec<OpaqueLazyAssociatedTestResults>> {
-            results.into_network_safe_chunks(
-                LARGE_MESSAGE_SIZE - Self::MAX_OVERHEAD_OF_RESPONSE_FOR_RESULTS,
-            )
-        }
     }
 
     /// ABQ-internal-ID for a grouping
@@ -721,48 +701,18 @@ pub mod queue {
             write!(f, "{}", uuid::Uuid::from_bytes_ref(&self.0))
         }
     }
-
-    #[cfg(test)]
-    mod test {
-        use crate::net_protocol::results::OpaqueLazyAssociatedTestResults;
-
-        use super::TestResultsResponse;
-
-        #[test]
-        fn max_overhead_of_response_for_results() {
-            let results = OpaqueLazyAssociatedTestResults::from_raw_json_lines(vec![
-                serde_json::value::to_raw_value(r#"RWXRWX"#).unwrap(),
-                serde_json::value::to_raw_value(r#"rwxrwx"#).unwrap(),
-            ]);
-            let results_len = serde_json::to_vec(&results).unwrap().len();
-
-            for final_chunk in [true, false] {
-                let response = TestResultsResponse::Results {
-                    chunk: results.clone(),
-                    final_chunk,
-                };
-                let response_len = serde_json::to_vec(&response).unwrap().len();
-
-                let overhead = response_len - results_len;
-
-                assert!(
-                    overhead <= TestResultsResponse::MAX_OVERHEAD_OF_RESPONSE_FOR_RESULTS,
-                    "{overhead}"
-                );
-            }
-        }
-    }
 }
 
 pub mod results {
-    use std::io;
-
     use serde_derive::{Deserialize, Serialize};
+    use tokio::io::AsyncBufReadExt;
 
-    use super::{
-        queue::{AssociatedTestResults, NativeRunnerInfo},
-        write_message_bytes_help,
+    use crate::{
+        error::{OpaqueResult, ResultLocation},
+        here,
     };
+
+    use super::queue::{AssociatedTestResults, NativeRunnerInfo};
 
     /// A line in the results-persistence scheme.
     #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -790,56 +740,30 @@ pub mod results {
             Self(opaque_lines)
         }
 
-        /// Splits the results into chunks that respect the [maximum network message size][MAX_MESSAGE_SIZE].
-        /// Assumes COMPRESS_LARGE is turned on, with the possibility of gz-encoded messages.
-        pub(super) fn into_network_safe_chunks(
-            self,
-            max_message_size: usize,
-        ) -> io::Result<Vec<Self>> {
-            // Preserve the order of test result lines across chunks.
-            // This is useful for reproducibility, even though the lines are opaque and can be
-            // processed out-of-order.
-            // As such, we keep a stack to process, initially populated in the same order as the
-            // opaque chunks.
-            let mut to_process = vec![self];
-            let mut processed = Vec::with_capacity(1);
-            while let Some(chunk) = to_process.pop() {
-                let (encoded_msg, _) = write_message_bytes_help::<
-                    _,
-                    true, /* COMPRESS_LARGE on */
-                >(&chunk, max_message_size)?;
-                if encoded_msg.len() > max_message_size {
-                    // Split the chunk in two.
-                    let half = chunk.0.len() / 2;
-                    let mut left = chunk.0;
-                    let right = left.split_off(half);
-                    if left.is_empty() || right.is_empty() {
-                        // The chunk was a singleton, and unfortunately, we can't split it any
-                        // further here.
-                        // TODO: we could get further by decoding the chunk into test results and
-                        // splitting those. However, I (Ayaz) suspect this will not be a problem in
-                        // practice unless someone is using a very large batch size.
-                        processed.push(OpaqueLazyAssociatedTestResults(left));
-                        processed.push(OpaqueLazyAssociatedTestResults(right));
-                    } else {
-                        // Push the chunks back on so that the first half (the left one) will be
-                        // processed first.
-                        to_process.push(OpaqueLazyAssociatedTestResults(right));
-                        to_process.push(OpaqueLazyAssociatedTestResults(left));
-                    }
-                } else {
-                    processed.push(chunk);
-                }
-            }
-            Ok(processed)
-        }
-
         pub fn decode(&self) -> serde_json::Result<Vec<ResultsLine>> {
             let mut results = Vec::with_capacity(self.0.len());
             for results_list in self.0.iter() {
                 results.push(serde_json::from_str(results_list.get())?);
             }
             Ok(results)
+        }
+
+        /// Reads the results from a reader that yields JSON lines.
+        pub async fn read_results_lines<Reader>(reader: &mut Reader) -> OpaqueResult<Self>
+        where
+            Reader: tokio::io::AsyncRead + Unpin,
+        {
+            let mut iter = tokio::io::BufReader::new(reader).lines();
+            let mut opaque_jsonl = vec![];
+            while let Some(line) = iter.next_line().await.located(here!())? {
+                match serde_json::value::RawValue::from_string(line.clone()).located(here!()) {
+                    Ok(line) => opaque_jsonl.push(line),
+                    Err(e) => {
+                        return Err(e);
+                    }
+                }
+            }
+            Ok(Self(opaque_jsonl))
         }
     }
 
@@ -872,43 +796,6 @@ pub mod results {
             let decoded: OpaqueLazyAssociatedTestResults = serde_json::from_str(&encoded).unwrap();
             assert_eq!(decoded.0.len(), 1);
             assert_eq!(decoded.0[0].get(), r#""hello""#);
-        }
-
-        #[test]
-        fn chunking() {
-            let results = OpaqueLazyAssociatedTestResults::from_raw_json_lines(vec![
-                // ["RWXRWX"] <- 10 bytes
-                serde_json::value::to_raw_value(r#"RWXRWX"#).unwrap(),
-                // ["R","R"] <- 9 bytes
-                serde_json::value::to_raw_value(r#"R"#).unwrap(),
-                serde_json::value::to_raw_value(r#"R"#).unwrap(),
-                // ["rwxrwx"] <- 10 bytes
-                serde_json::value::to_raw_value(r#"rwxrwx"#).unwrap(),
-                // ["r","r"] <- 9 bytes
-                serde_json::value::to_raw_value(r#"r"#).unwrap(),
-                serde_json::value::to_raw_value(r#"r"#).unwrap(),
-            ]);
-
-            let expected_chunks = vec![
-                OpaqueLazyAssociatedTestResults::from_raw_json_lines(vec![
-                    serde_json::value::to_raw_value(r#"RWXRWX"#).unwrap(),
-                ]),
-                OpaqueLazyAssociatedTestResults::from_raw_json_lines(vec![
-                    serde_json::value::to_raw_value(r#"R"#).unwrap(),
-                    serde_json::value::to_raw_value(r#"R"#).unwrap(),
-                ]),
-                OpaqueLazyAssociatedTestResults::from_raw_json_lines(vec![
-                    serde_json::value::to_raw_value(r#"rwxrwx"#).unwrap(),
-                ]),
-                OpaqueLazyAssociatedTestResults::from_raw_json_lines(vec![
-                    serde_json::value::to_raw_value(r#"r"#).unwrap(),
-                    serde_json::value::to_raw_value(r#"r"#).unwrap(),
-                ]),
-            ];
-
-            let chunks = results.into_network_safe_chunks(10).unwrap();
-            assert_eq!(chunks.len(), 4, "{chunks:?}");
-            assert_eq!(chunks, expected_chunks);
         }
     }
 }
@@ -1360,6 +1247,39 @@ where
     //
     //   https://github.com/tokio-rs/tls/blob/master/tokio-rustls/src/client.rs#L138-L139
     writer.write_all(&msg_buf).await?;
+    writer.flush().await?;
+
+    Ok(())
+}
+
+/// Performs a buffered copy of the given stream to the given writer.
+///
+/// The buffer size is currently given by `tokio::io::copy`, which is 8 KiB.
+///
+///   https://docs.rs/tokio/latest/tokio/io/fn.copy.html
+pub async fn async_write_stream<R, S>(
+    writer: &mut R,
+    _stream_length: u32,
+    stream: &mut S,
+) -> Result<(), std::io::Error>
+where
+    R: tokio::io::AsyncWriteExt + Unpin,
+    S: tokio::io::AsyncRead + Unpin,
+{
+    //let msg_size_buf = { i32::to_be_bytes(stream_length as i32) };
+
+    //writer.write_all(&msg_size_buf).await?;
+
+    tokio::io::copy(stream, writer).await?;
+
+    // NB: to be safe, always flush after writing. [tokio::io::AsyncWrite::poll_write] makes no
+    // guarantee about the behavior after `write_all`, including whether the implementing type must
+    // flush any intermediate buffers upon destruction.
+    //
+    // In fact, our tokio-tls shim does not ensure TLS frames are flushed upon connection
+    // destruction:
+    //
+    //   https://github.com/tokio-rs/tls/blob/master/tokio-rustls/src/client.rs#L138-L139
     writer.flush().await?;
 
     Ok(())

--- a/crates/abq_utils/src/net_protocol.rs
+++ b/crates/abq_utils/src/net_protocol.rs
@@ -767,6 +767,17 @@ pub mod results {
             }
             Ok(Self(opaque_jsonl))
         }
+
+        pub fn into_jsonl_buffer(
+            lines: &[Box<serde_json::value::RawValue>],
+        ) -> OpaqueResult<Vec<u8>> {
+            let mut buffer: Vec<u8> = Vec::new();
+            for json_line in lines {
+                serde_json::to_writer(&mut buffer, json_line).located(here!())?;
+                buffer.push(b'\n');
+            }
+            Ok(buffer)
+        }
     }
 
     impl PartialEq for OpaqueLazyAssociatedTestResults {

--- a/crates/abq_utils/src/net_protocol.rs
+++ b/crates/abq_utils/src/net_protocol.rs
@@ -1611,4 +1611,24 @@ mod test {
         assert_eq!(num_read, msg.len());
         assert_eq!(msg, output_buffer);
     }
+
+    #[tokio::test]
+    async fn read_steam_only_given_length() {
+        let mut read_buffer = vec![];
+        // message size
+        read_buffer.extend_from_slice(&i32::to_be_bytes(2));
+        // message + cdef
+        read_buffer.extend_from_slice(b"abcdef");
+
+        let mut write_buffer = vec![];
+
+        super::async_read_stream(&mut read_buffer.as_slice())
+            .await
+            .unwrap()
+            .read_to_end(&mut write_buffer)
+            .await
+            .unwrap();
+
+        assert_eq!(write_buffer, b"ab");
+    }
 }


### PR DESCRIPTION
Prior to this commit, an ABQ server would always load test results into memory before streaming them to the client. This could result in DOS of the server.

In this patch, we instead stream the results file to the client, but without loading the results into memory. At a given time, at most 8KB of a results file will be loaded in the server memory.

Note that the client still must load all results into memory, and can still suffer a DOS.