### PR TITLE
Log warnings when workers have different commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 ## 1.6.2
 
-ABQ 1.6.2 is a patch release fixing an issue that could result in
-denial-of-service of an ABQ queue due to large test results.
+ABQ 1.6.2 is a patch release.
+
+An issue that could result in denial-of-service of an ABQ queue due to large
+test results is fixed.
+
+ABQ will now log a warning when a worker for a given run ID is using a test
+command different from any other worker, either in the same run or during
+retries. ABQ may not function properly if the test command for a run ID changes
+between workers executing tests for that run ID.
 
 ## 1.6.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ name = "abq_queue"
 version = "0.1.0"
 dependencies = [
  "abq_native_runner_simulation",
+ "abq_reporting",
  "abq_run_n_times",
  "abq_test_utils",
  "abq_utils",
@@ -252,6 +253,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "blake3",
  "derive_more",
  "flate2",
  "insta",
@@ -284,6 +286,7 @@ name = "abq_workers"
 version = "0.1.0"
 dependencies = [
  "abq_generic_test_runner",
+ "abq_reporting",
  "abq_run_n_times",
  "abq_test_utils",
  "abq_utils",
@@ -347,10 +350,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "assert-json-diff"
@@ -803,6 +818,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake3"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729b71f35bd3fa1a4c86b85d32c8b9069ea7fe14f7a53cfabb65f62d4265b888"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.4",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +1001,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "convert_case"
@@ -3265,7 +3300,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "utf8parse",
  "vte_generate_state_changes",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "abq"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "abq_dot_reporter",
  "abq_hosted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 
+blake3 = "=1.4.0"
+
 tracing = { version = "0.1.37", features = ["release_max_level_info"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
 tracing-appender = "0.2.2"

--- a/crates/abq_cli/Cargo.toml
+++ b/crates/abq_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abq"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 
 [dependencies]

--- a/crates/abq_cli/src/reporting.rs
+++ b/crates/abq_cli/src/reporting.rs
@@ -267,6 +267,10 @@ impl StdoutPreferences {
     pub fn stdout_stream(&self) -> impl termcolor::WriteColor {
         StandardStream::stdout(self.color)
     }
+
+    pub fn stderr_stream(&self) -> impl termcolor::WriteColor {
+        StandardStream::stderr(self.color)
+    }
 }
 
 fn reporter_from_kind(

--- a/crates/abq_cli/src/workers.rs
+++ b/crates/abq_cli/src/workers.rs
@@ -85,7 +85,10 @@ pub async fn start_workers_standalone(
         run_id: run_id.clone(),
         batch_size_hint: batch_size,
         test_strategy,
+        test_command_hash: runner_kind.command_hash(),
     };
+
+    let stderr_writer = Box::new(stdout_preferences.stderr_stream());
 
     let mut worker_pool = WorkersNegotiator::negotiate_and_start_pool(
         WorkersConfig {
@@ -101,6 +104,7 @@ pub async fn start_workers_standalone(
             results_batch_size_hint: batch_size.get(),
             max_run_number,
             should_send_results: execution_mode == ExecutionMode::WriteNormal,
+            warning_writer: stderr_writer,
         },
         queue_negotiator,
         client_opts,

--- a/crates/abq_queue/Cargo.toml
+++ b/crates/abq_queue/Cargo.toml
@@ -38,6 +38,7 @@ s3 = [
 ]
 
 [dev-dependencies]
+abq_reporting = { path = "../abq_reporting" }
 abq_utils = { path = "../abq_utils", features = ["expose-native-protocols"] }
 abq_test_utils = { path = "../abq_test_support/abq_test_utils" }
 abq_with_protocol_version = { path = "../abq_test_support/with_protocol_version" }

--- a/crates/abq_queue/src/queue/test_utils.rs
+++ b/crates/abq_queue/src/queue/test_utils.rs
@@ -1,0 +1,52 @@
+#![cfg(test)]
+use abq_test_utils::one_nonzero_usize;
+use abq_utils::{
+    net_protocol::{
+        entity::Entity,
+        queue::{TestSpec, TestStrategy},
+        runners::ProtocolWitness,
+        workers::RunId,
+    },
+    test_command_hash::TestCommandHash,
+};
+
+use crate::persistence::remote::RemotePersister;
+
+use super::RunParams;
+
+pub fn fake_test_spec(proto: ProtocolWitness) -> TestSpec {
+    use abq_utils::net_protocol::{runners::TestCase, workers::WorkId};
+
+    TestSpec {
+        test_case: TestCase::new(proto, "fake-test", Default::default()),
+        work_id: WorkId::new(),
+    }
+}
+
+pub struct RunParamsBuilder<'a>(RunParams<'a>);
+impl<'a> RunParamsBuilder<'a> {
+    pub fn new(run_id: &'a RunId, remote: &'a RemotePersister) -> Self {
+        Self(RunParams {
+            run_id,
+            batch_size_hint: one_nonzero_usize(),
+            test_strategy: TestStrategy::ByTest,
+            entity: Entity::runner(0, 1),
+            remote,
+            runner_test_command_hash: TestCommandHash::random(),
+        })
+    }
+
+    pub fn entity(mut self, entity: Entity) -> Self {
+        self.0.entity = entity;
+        self
+    }
+
+    pub fn runner_test_command_hash(mut self, hash: TestCommandHash) -> Self {
+        self.0.runner_test_command_hash = hash;
+        self
+    }
+
+    pub(super) fn build(self) -> RunParams<'a> {
+        self.0
+    }
+}

--- a/crates/abq_queue/tests/integration.rs
+++ b/crates/abq_queue/tests/integration.rs
@@ -20,6 +20,7 @@ use abq_queue::{
     queue::{Abq, QueueConfig},
     RunTimeoutStrategy, TimeoutReason,
 };
+use abq_reporting::writer::NoopColorWriter;
 use abq_test_utils::{artifacts_dir, assert_scoped_log, s};
 use abq_utils::{
     auth::{ClientAuthStrategy, User},
@@ -271,6 +272,7 @@ impl WorkersConfigBuilder {
             protocol_version_timeout: DEFAULT_PROTOCOL_VERSION_TIMEOUT,
             test_timeout: DEFAULT_RUNNER_TEST_TIMEOUT,
             should_send_results: true,
+            warning_writer: Box::new(NoopColorWriter),
         };
         Self {
             config,
@@ -494,6 +496,7 @@ fn action_to_fut(
                 run_id,
                 batch_size_hint: one_nonzero(),
                 test_strategy,
+                test_command_hash: config.runner_kind.command_hash(),
             };
 
             let config = WorkersConfig {

--- a/crates/abq_reporting/src/lib.rs
+++ b/crates/abq_reporting/src/lib.rs
@@ -8,6 +8,8 @@ use abq_utils::net_protocol::{
 pub mod colors;
 pub mod output;
 
+pub mod writer;
+
 #[must_use]
 #[derive(Debug)]
 pub struct CompletedSummary {

--- a/crates/abq_reporting/src/output.rs
+++ b/crates/abq_reporting/src/output.rs
@@ -425,7 +425,7 @@ fn green_bold_spec() -> ColorSpec {
 }
 
 #[inline]
-fn yellow_bold_spec() -> ColorSpec {
+pub fn yellow_bold_spec() -> ColorSpec {
     let mut spec = ColorSpec::new();
     spec.set_fg(Some(Color::Yellow)).set_bold(true);
     spec

--- a/crates/abq_reporting/src/writer.rs
+++ b/crates/abq_reporting/src/writer.rs
@@ -1,0 +1,42 @@
+use crate::output::yellow_bold_spec;
+
+pub trait ColorWriter {
+    fn warn_line(&mut self, msg: &str) -> std::io::Result<()>;
+}
+
+pub struct NoopColorWriter;
+
+impl std::io::Write for NoopColorWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl termcolor::WriteColor for NoopColorWriter {
+    fn supports_color(&self) -> bool {
+        false
+    }
+
+    fn set_color(&mut self, _: &termcolor::ColorSpec) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn reset(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<T: termcolor::WriteColor> ColorWriter for T {
+    fn warn_line(&mut self, message: &str) -> std::io::Result<()> {
+        self.set_color(&yellow_bold_spec())?;
+        self.write_all(b"WARNING: ")?;
+        self.write_all(message.as_bytes())?;
+        self.write_all(b"\n")?;
+        self.reset()?;
+        Ok(())
+    }
+}

--- a/crates/abq_utils/Cargo.toml
+++ b/crates/abq_utils/Cargo.toml
@@ -20,6 +20,8 @@ rand.workspace = true
 rand_chacha.workspace = true
 uuid.workspace = true
 
+blake3.workspace = true
+
 thiserror.workspace = true
 async-trait.workspace = true
 parking_lot.workspace = true

--- a/crates/abq_utils/src/lib.rs
+++ b/crates/abq_utils/src/lib.rs
@@ -13,6 +13,7 @@ pub mod oneshot_notify;
 pub mod results_handler;
 pub mod retry;
 pub mod server_shutdown;
+pub mod test_command_hash;
 pub mod time;
 pub mod timeout_future;
 pub mod tls;

--- a/crates/abq_utils/src/net_protocol.rs
+++ b/crates/abq_utils/src/net_protocol.rs
@@ -235,7 +235,7 @@ pub mod workers {
         queue::TestSpec,
         runners::{AbqProtocolVersion, Manifest, ManifestMessage, NativeRunnerSpecification},
     };
-    use crate::capture_output::StdioOutput;
+    use crate::{capture_output::StdioOutput, test_command_hash::TestCommandHash};
     use serde_derive::{Deserialize, Serialize};
     use std::{
         collections::HashMap,
@@ -377,6 +377,17 @@ pub mod workers {
                 }
             }
         }
+
+        pub fn command_hash(&self) -> TestCommandHash {
+            match self {
+                RunnerKind::GenericNativeTestRunner(params) => {
+                    TestCommandHash::from_command(&params.cmd, &params.args)
+                }
+                RunnerKind::TestLikeRunner(_, _) => {
+                    TestCommandHash::from_command("test-like-runner", &[])
+                }
+            }
+        }
     }
 
     #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -470,7 +481,7 @@ pub mod queue {
         runners::{AbqProtocolVersion, NativeRunnerSpecification, TestCase, TestResult},
         workers::{ManifestResult, RunId, WorkId},
     };
-    use crate::capture_output::StdioOutput;
+    use crate::{capture_output::StdioOutput, test_command_hash::TestCommandHash};
 
     /// Information about the queue and its negotiation server.
     #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -535,6 +546,7 @@ pub mod queue {
         pub run_id: RunId,
         pub batch_size_hint: NonZeroU64,
         pub test_strategy: TestStrategy,
+        pub test_command_hash: TestCommandHash,
     }
 
     /// Specification of a test case to run.

--- a/crates/abq_utils/src/test_command_hash.rs
+++ b/crates/abq_utils/src/test_command_hash.rs
@@ -1,0 +1,54 @@
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+pub struct TestCommandHash([u8; 32]);
+
+impl TestCommandHash {
+    pub fn from_command(command: &str, args: &[String]) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(command.as_bytes());
+        for arg in args {
+            hasher.update(arg.as_bytes());
+        }
+        Self(hasher.finalize().into())
+    }
+
+    pub fn random() -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&rand::random::<[u8; 32]>());
+        Self(hasher.finalize().into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::TestCommandHash;
+
+    #[test]
+    fn random_is_random() {
+        let one = TestCommandHash::random();
+        let two = TestCommandHash::random();
+        assert_ne!(one, two);
+    }
+
+    #[test]
+    fn consistent_for_same_command() {
+        let one = TestCommandHash::from_command("foo", &["arg1".into()]);
+        let two = TestCommandHash::from_command("foo", &["arg1".into()]);
+        assert_eq!(one, two);
+    }
+
+    #[test]
+    fn different_for_different_command() {
+        let one = TestCommandHash::from_command("foo", &["arg1".into()]);
+        let two = TestCommandHash::from_command("bar", &["arg1".into()]);
+        assert_ne!(one, two);
+    }
+
+    #[test]
+    fn different_for_different_args() {
+        let one = TestCommandHash::from_command("foo", &["arg1".into()]);
+        let two = TestCommandHash::from_command("foo", &["arg2".into()]);
+        assert_ne!(one, two);
+    }
+}

--- a/crates/abq_workers/Cargo.toml
+++ b/crates/abq_workers/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [dependencies]
 abq_generic_test_runner = { path = "../abq_runners/generic_test_runner" }
+abq_reporting = { path = "../abq_reporting" }
 abq_utils = { path = "../abq_utils" }
 
 thiserror.workspace = true

--- a/crates/abq_workers/src/assigned_run.rs
+++ b/crates/abq_workers/src/assigned_run.rs
@@ -4,11 +4,19 @@ use serde_derive::{Deserialize, Serialize};
 
 /// The test run a worker should ask for work on.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-pub enum AssignedRun {
+pub enum AssignedRunKind {
     /// This worker is connecting for a fresh run, and should fetch tests online.
     Fresh { should_generate_manifest: bool },
     /// This worker is connecting for a retry, and should fetch its manifest from the queue once.
     Retry,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct AssignedRun {
+    pub kind: AssignedRunKind,
+    /// [true] if the runner test command differs from the one associated when the run was
+    /// created.
+    pub runner_test_command_differs: bool,
 }
 
 #[must_use]
@@ -27,8 +35,11 @@ impl AssignedRunStatus {
     pub fn freshly_created(&self) -> bool {
         matches!(
             self,
-            AssignedRunStatus::Run(AssignedRun::Fresh {
-                should_generate_manifest: true
+            AssignedRunStatus::Run(AssignedRun {
+                kind: AssignedRunKind::Fresh {
+                    should_generate_manifest: true,
+                },
+                ..
             })
         )
     }

--- a/crates/abq_workers/src/lib.rs
+++ b/crates/abq_workers/src/lib.rs
@@ -9,4 +9,4 @@ pub mod workers;
 
 pub use abq_generic_test_runner::DEFAULT_PROTOCOL_VERSION_TIMEOUT;
 pub use abq_generic_test_runner::DEFAULT_RUNNER_TEST_TIMEOUT;
-pub use assigned_run::{AssignedRun, AssignedRunStatus, GetAssignedRun};
+pub use assigned_run::{AssignedRun, AssignedRunKind, AssignedRunStatus, GetAssignedRun};

--- a/crates/abq_workers/src/runner_strategy.rs
+++ b/crates/abq_workers/src/runner_strategy.rs
@@ -24,7 +24,7 @@ use crate::{
     results_handler::{MultiplexingResultsHandler, QueueResultsSender},
     test_fetching,
     workers::{GetInitContext, InitContextResult, NotifyManifest, NotifyMaterialTestsAllRun},
-    AssignedRun,
+    AssignedRunKind,
 };
 
 pub struct RunnerStrategy {
@@ -49,7 +49,7 @@ pub struct RunnerStrategyGenerator {
     work_server_addr: SocketAddr,
     local_results_handler: SharedResultsHandler,
     max_run_number: u32,
-    assigned: AssignedRun,
+    assigned: AssignedRunKind,
     should_send_results: bool,
 }
 
@@ -61,7 +61,7 @@ impl RunnerStrategyGenerator {
         work_server_addr: SocketAddr,
         local_results_handler: SharedResultsHandler,
         max_run_number: u32,
-        assigned: AssignedRun,
+        assigned: AssignedRunKind,
         should_send_results: bool,
     ) -> Self {
         Self {
@@ -91,8 +91,8 @@ impl StrategyGenerator for RunnerStrategyGenerator {
         } = &self;
 
         let sourcing_strategy = match assigned {
-            AssignedRun::Fresh { .. } => test_fetching::SourcingStrategy::Fresh,
-            AssignedRun::Retry => test_fetching::SourcingStrategy::Retry,
+            AssignedRunKind::Fresh { .. } => test_fetching::SourcingStrategy::Fresh,
+            AssignedRunKind::Retry => test_fetching::SourcingStrategy::Retry,
         };
 
         let (tests_fetcher, results_retry_tracker) = test_fetching::Fetcher::new(


### PR DESCRIPTION
The command passed to a native test runner is now cryptographically hashed
and stored alongside a run ID. If a worker connects and has
a command different from the command given to the worker that
initialized run, log a warning on both the worker and the server.

This is backwards compatible. Older runs loaded on a queue won't have
their command hashes checked.