### PR TITLE
Report hosted queue errors regardless of token kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.6.4
+
+ABQ 1.6.4 is a patch release.
+
+Prior to this release, using `abq test` or `abq report` with an RWX organization
+access token to connect to a hosted queue that failed to find an appropriate
+queue would result in the ABQ invocation falling back to local mode. Now, ABQ
+will exit with an error.
+
 ## 1.6.3
 
 ABQ 1.6.3 is a patch release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "abq"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "abq_dot_reporter",
  "abq_hosted",

--- a/crates/abq_cli/Cargo.toml
+++ b/crates/abq_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abq"
-version = "1.6.3"
+version = "1.6.4"
 edition = "2021"
 
 [dependencies]

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -664,7 +664,7 @@ struct QueueLocationConfig {
 
 fn determine_queue_location(config: QueueLocationConfig) -> QueueLocation {
     match config.access_token_kind {
-        Some(AccessTokenKind::Personal) => {
+        Some(_) => {
             match (
                 config.run_id_provided,
                 config.usage_error_from_api,
@@ -680,7 +680,7 @@ fn determine_queue_location(config: QueueLocationConfig) -> QueueLocation {
                 },
             }
         }
-        _ => match config.queue_addr {
+        None => match config.queue_addr {
             Some(queue_addr) => QueueLocation::Remote(queue_addr),
             None => QueueLocation::Ephemeral {
                 opt_tls_key: config.tls_key,


### PR DESCRIPTION
Prior to this patch, ABQ would fall back to attempting to using an
ephemeral queue if an organization access token was used with the hosted
API and the hosted API returned an unsupported queue error. However, ABQ
should exit unconditionally with the error message in such cases.

A test for `abq test` and `abq report` is included.
