### PR TITLE
Instruct runners to always pull from online queue after getting their server-side retry manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ ABQ 1.7.0 is a minor release.
 This release improves ABQ's behavior when an ABQ runner is terminated before
 being assigned all applicable test in a run manifest. In previous versions of
 ABQ, retrying such a runner would only retry the tests the runner was assigned
-before it termianted. Starting with ABQ 1.7.0, a runner that connects for a run
+before it terminated. Starting with ABQ 1.7.0, a runner that connects for a run
 ID after it was terminated will run all tests it ran on its first connection,
 and then pull tests from the run queue.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.7.0
+
+ABQ 1.7.0 is a minor release.
+
+This release improves ABQ's behavior when an ABQ runner is terminated before
+being assigned all applicable test in a run manifest. In previous versions of
+ABQ, retrying such a runner would only retry the tests the runner was assigned
+before it termianted. Starting with ABQ 1.7.0, a runner that connects for a run
+ID after it was terminated will run all tests it ran on its first connection,
+and then pull tests from the run queue.
+
+ABQ continues to cancel runs when a runner is terminated with SIGTERM, SIGINT,
+or SIGQUIT. The changes in 1.7.0 apply to runners terminated in other ways, for
+example via SIGKILL.
+
 ## 1.6.4
 
 ABQ 1.6.4 is a patch release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "abq"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "abq_dot_reporter",
  "abq_hosted",

--- a/crates/abq_cli/Cargo.toml
+++ b/crates/abq_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abq"
-version = "1.6.4"
+version = "1.6.5"
 edition = "2021"
 
 [dependencies]

--- a/crates/abq_cli/src/report.rs
+++ b/crates/abq_cli/src/report.rs
@@ -293,7 +293,7 @@ async fn wait_for_results_help(
             }
             RunInProgress { active_runners } => {
                 if active_runners.is_empty() {
-                    bail!("this ABQ run has not assigned all tests in your test suite, but there are no active runners to assign them to. Please either add more runners, or launch a new run.")
+                    bail!("this ABQ run has not assigned all tests in your test suite, but there are no active runners to assign them to. Please retry a runner, add more runners, or launch a new run.")
                 }
 
                 let active_runners = active_runners

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -5066,8 +5066,7 @@ fn retry_continued_manifest_read_on_worker_death() {
                         OpaqueRead,
                         OpaqueWrite(pack(InitSuccessMessage::new(proto))),
                         // Read first test, write okay
-                        OpaqueRead,
-                        OpaqueWrite(pack(RawTestResultMessage::fake(proto))),
+                        IfAliveReadAndWriteFake(Status::Success),
                         Stdout("finished running first test\n".into()),
                     ];
                     if i == 1 {
@@ -5075,9 +5074,7 @@ fn retry_continued_manifest_read_on_worker_death() {
                         actions.push(Sleep(Duration::from_secs(600)));
                     } else {
                         for _ in 0..3 {
-                            // Second run: read the next test, write okay
-                            actions.push(OpaqueRead);
-                            actions.push(OpaqueWrite(pack(RawTestResultMessage::fake(proto))));
+                            actions.push(IfAliveReadAndWriteFake(Status::Success));
                         }
                     }
                     actions
@@ -5149,7 +5146,10 @@ fn retry_continued_manifest_read_on_worker_death() {
         } = Abq::new(format!("{name}_worker0_attempt1"))
             .args(test_args)
             .run();
-        assert!(exit_status.success());
+        assert!(
+            exit_status.success(),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
         assert!(
             stdout.contains("4 tests, 0 failures"),
             "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"

--- a/crates/abq_cli/tests/cli.rs
+++ b/crates/abq_cli/tests/cli.rs
@@ -417,12 +417,15 @@ fn wait_for_live_worker(worker_stderr: &mut ChildStderr) {
 
 // Waits for the debug line "starting execution of all tests" in the worker.
 fn wait_for_worker_executing(worker_stderr: &mut ChildStderr) {
-    let mut worker_reader = BufReader::new(worker_stderr).lines();
-    // Spin until we know the worker0 is UP
+    wait_for_line(worker_stderr, "starting execution of all tests");
+}
+
+fn wait_for_line<R: std::io::Read>(reader: R, output: &str) {
+    let mut reader = BufReader::new(reader).lines();
     loop {
-        if let Some(line) = worker_reader.next() {
+        if let Some(line) = reader.next() {
             let line = line.expect("line is not a string");
-            if line.contains("starting execution of all tests") {
+            if line.contains(output) {
                 break;
             }
         }
@@ -5016,4 +5019,155 @@ fn write_partial_rwx_v1_json_results_on_early_runner_termination() {
       ]
     }
     "###);
+}
+
+#[test]
+#[with_protocol_version]
+#[serial]
+fn retry_continued_manifest_read_on_worker_death() {
+    let name = "retry_continued_manifest_read_on_worker_death";
+    let conf = CSConfigOptions {
+        use_auth_token: true,
+        tls: true,
+    };
+
+    let (_queue_proc, queue_addr) = setup_queue!(name, conf);
+
+    let proto = AbqProtocolVersion::V0_2.get_supported_witness().unwrap();
+
+    let manifest = (0..4)
+        .map(|i| {
+            TestOrGroup::test(Test::new(
+                proto,
+                format!("test{}", i),
+                [],
+                Default::default(),
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    let manifest = ManifestMessage::new(Manifest::new(manifest, Default::default()));
+
+    let make_simulation = |i| {
+        [
+            Connect,
+            //
+            // Write spawn message
+            OpaqueWrite(pack(legal_spawned_message(proto))),
+            //
+            // Write the manifest if we need to.
+            // Otherwise handle the one test.
+            IfGenerateManifest {
+                then_do: vec![OpaqueWrite(pack(&manifest))],
+                else_do: {
+                    let mut actions = vec![
+                        //
+                        // Read init context message + write ACK
+                        OpaqueRead,
+                        OpaqueWrite(pack(InitSuccessMessage::new(proto))),
+                        // Read first test, write okay
+                        OpaqueRead,
+                        OpaqueWrite(pack(RawTestResultMessage::fake(proto))),
+                        Stdout("finished running first test\n".into()),
+                    ];
+                    if i == 1 {
+                        // First run: sleep forever, we will kill the worker.
+                        actions.push(Sleep(Duration::from_secs(600)));
+                    } else {
+                        for _ in 0..3 {
+                            // Second run: read the next test, write okay
+                            actions.push(OpaqueRead);
+                            actions.push(OpaqueWrite(pack(RawTestResultMessage::fake(proto))));
+                        }
+                    }
+                    actions
+                },
+            },
+            //
+            // Finish
+            Exit(0),
+        ]
+    };
+
+    let simulation1 = make_simulation(1);
+    let simulation2 = make_simulation(2);
+
+    let packed = pack_msgs_to_disk(simulation1);
+
+    let run_id = "test-run-id";
+
+    let test_args = {
+        let simulator = native_runner_simulation_bin();
+        let simfile_path = packed.path.display().to_string();
+        let args = vec![
+            format!("test"),
+            format!("--worker=0"),
+            format!("--queue-addr={queue_addr}"),
+            format!("--run-id={run_id}"),
+            format!("--batch-size=1"),
+        ];
+        let mut args = conf.extend_args_for_client(args);
+        args.extend([s!("--"), simulator, simfile_path]);
+        args
+    };
+
+    let report_args = {
+        let args = vec![
+            format!("report"),
+            format!("--reporter=dot"),
+            format!("--queue-addr={queue_addr}"),
+            format!("--run-id={run_id}"),
+            format!("--color=never"),
+        ];
+        conf.extend_args_for_client(args)
+    };
+
+    let mut worker0_attempt1 = Abq::new(format!("{name}_worker0_attempt1"))
+        .args(&test_args)
+        .spawn();
+
+    let attempt1_stdout = worker0_attempt1.stdout.as_mut().unwrap();
+    wait_for_line(attempt1_stdout, "finished running first test");
+
+    // Kill the worker.
+    worker0_attempt1.kill().unwrap();
+
+    {
+        let CmdOutput { exit_status, .. } = Abq::new(name.to_string() + "_report1")
+            .args(&report_args)
+            .run();
+        assert!(!exit_status.success());
+    }
+
+    std::fs::write(packed.path, pack_msgs(simulation2)).unwrap();
+
+    {
+        let CmdOutput {
+            stdout,
+            stderr,
+            exit_status,
+        } = Abq::new(format!("{name}_worker0_attempt1"))
+            .args(test_args)
+            .run();
+        assert!(exit_status.success());
+        assert!(
+            stdout.contains("4 tests, 0 failures"),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+    }
+
+    {
+        let CmdOutput {
+            stdout,
+            stderr,
+            exit_status,
+        } = Abq::new(name.to_string() + "_report2")
+            .args(report_args)
+            .run();
+        assert!(exit_status.success());
+        assert!(
+            stdout.contains("4 tests, 0 failures"),
+            "STDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        );
+    }
 }

--- a/crates/abq_workers/src/assigned_run.rs
+++ b/crates/abq_workers/src/assigned_run.rs
@@ -9,6 +9,8 @@ pub enum AssignedRunKind {
     Fresh { should_generate_manifest: bool },
     /// This worker is connecting for a retry, and should fetch its manifest from the queue once.
     Retry,
+    /// This worker should pull the retry manifest, and then continue to fetch tests online.
+    RetryAndContinue,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/crates/abq_workers/src/assigned_run.rs
+++ b/crates/abq_workers/src/assigned_run.rs
@@ -7,9 +7,7 @@ use serde_derive::{Deserialize, Serialize};
 pub enum AssignedRunKind {
     /// This worker is connecting for a fresh run, and should fetch tests online.
     Fresh { should_generate_manifest: bool },
-    /// This worker is connecting for a retry, and should fetch its manifest from the queue once.
-    Retry,
-    /// This worker should pull the retry manifest, and then continue to fetch tests online.
+    /// This worker should pull its retry manifest, and then continue to fetch tests online.
     RetryAndContinue,
 }
 

--- a/crates/abq_workers/src/negotiate.rs
+++ b/crates/abq_workers/src/negotiate.rs
@@ -248,7 +248,7 @@ impl WorkersNegotiator {
             AssignedRunKind::Fresh {
                 should_generate_manifest,
             } => should_generate_manifest,
-            AssignedRunKind::Retry | AssignedRunKind::RetryAndContinue => false,
+            AssignedRunKind::RetryAndContinue => false,
         };
 
         let runner_strategy_generator = RunnerStrategyGenerator::new(

--- a/crates/abq_workers/src/negotiate.rs
+++ b/crates/abq_workers/src/negotiate.rs
@@ -248,7 +248,7 @@ impl WorkersNegotiator {
             AssignedRunKind::Fresh {
                 should_generate_manifest,
             } => should_generate_manifest,
-            AssignedRunKind::Retry => false,
+            AssignedRunKind::Retry | AssignedRunKind::RetryAndContinue => false,
         };
 
         let runner_strategy_generator = RunnerStrategyGenerator::new(

--- a/crates/abq_workers/src/runner_strategy.rs
+++ b/crates/abq_workers/src/runner_strategy.rs
@@ -91,8 +91,12 @@ impl StrategyGenerator for RunnerStrategyGenerator {
         } = &self;
 
         let sourcing_strategy = match assigned {
-            AssignedRunKind::Fresh { .. } => test_fetching::SourcingStrategy::Fresh,
-            AssignedRunKind::Retry => test_fetching::SourcingStrategy::Retry,
+            AssignedRunKind::Fresh { .. } => vec![test_fetching::SourcingStrategy::Queue],
+            AssignedRunKind::Retry => vec![test_fetching::SourcingStrategy::RetryManifest],
+            AssignedRunKind::RetryAndContinue => vec![
+                test_fetching::SourcingStrategy::RetryManifest,
+                test_fetching::SourcingStrategy::Queue,
+            ],
         };
 
         let (tests_fetcher, results_retry_tracker) = test_fetching::Fetcher::new(

--- a/crates/abq_workers/src/runner_strategy.rs
+++ b/crates/abq_workers/src/runner_strategy.rs
@@ -92,7 +92,6 @@ impl StrategyGenerator for RunnerStrategyGenerator {
 
         let sourcing_strategy = match assigned {
             AssignedRunKind::Fresh { .. } => vec![test_fetching::SourcingStrategy::Queue],
-            AssignedRunKind::Retry => vec![test_fetching::SourcingStrategy::RetryManifest],
             AssignedRunKind::RetryAndContinue => vec![
                 test_fetching::SourcingStrategy::RetryManifest,
                 test_fetching::SourcingStrategy::Queue,

--- a/crates/abq_workers/src/test_fetching.rs
+++ b/crates/abq_workers/src/test_fetching.rs
@@ -39,7 +39,7 @@ use retries::RetryTracker;
 /// NEW_PROCESS_RETRY: takes the place of FRESH if this is a re-run of a previously-completed
 /// execution of a test suite by a worker.
 pub struct Fetcher {
-    initial_source: Option<InitialSource>,
+    initial_sources_rev: Vec<InitialSource>,
     retry_source: RetryTracker,
     pending_retry_manifest_wait_time: Duration,
 }
@@ -48,23 +48,21 @@ const DEFAULT_PENDING_RETRY_MANIFEST_WAIT_TIME: Duration = Duration::from_millis
 
 /// How the initial manifest from the queue should be sourced.
 pub enum SourcingStrategy {
-    /// This runner is new to the given test; use the FRESH strategy.
-    Fresh,
-    /// This runner is retrying a given test run; use NEW_PROCESS_RETRY strategy.
-    Retry,
+    Queue,
+    RetryManifest,
 }
 
 impl Fetcher {
     pub fn new(
-        sourcing_strategy: SourcingStrategy,
+        sourcing_strategies: impl IntoIterator<Item = SourcingStrategy>,
         entity: Entity,
         work_server_addr: SocketAddr,
         client: Box<dyn ConfiguredClient>,
         run_id: RunId,
         max_run_number: u32,
     ) -> (Self, ResultsTracker) {
-        let initial_source = InitialSource::from_strategy(
-            sourcing_strategy,
+        let initial_source = InitialSource::from_strategies(
+            sourcing_strategies,
             entity,
             work_server_addr,
             client,
@@ -79,13 +77,13 @@ impl Fetcher {
     }
 
     fn new_help(
-        initial_source: InitialSource,
+        initial_sources: Vec<InitialSource>,
         max_run_number: u32,
         pending_retry_manifest_wait_time: Duration,
     ) -> (Self, ResultsTracker) {
         let (retry_source, results_tracker) = retries::build_tracking_pair(max_run_number);
         let me = Self {
-            initial_source: Some(initial_source),
+            initial_sources_rev: initial_sources.into_iter().rev().collect(),
             retry_source,
             pending_retry_manifest_wait_time,
         };
@@ -93,10 +91,9 @@ impl Fetcher {
     }
 }
 
-/// The initial source of tests; this is either FRESH or NEW_PROCESS_RETRY.
 enum InitialSource {
-    Fresh(PersistedTestsFetcher),
-    Retry(OutOfProcessRetryManifestFetcher),
+    Queue(PersistedTestsFetcher),
+    ServerRetryManifest(OutOfProcessRetryManifestFetcher),
 }
 
 impl InitialSource {
@@ -108,19 +105,37 @@ impl InitialSource {
         run_id: RunId,
     ) -> Self {
         match strategy {
-            SourcingStrategy::Fresh => Self::Fresh(persistent_test_fetcher::start(
+            SourcingStrategy::Queue => Self::Queue(persistent_test_fetcher::start(
                 entity,
                 work_server_addr,
                 client,
                 run_id,
             )),
-            SourcingStrategy::Retry => Self::Retry(OutOfProcessRetryManifestFetcher::new(
-                entity,
-                work_server_addr,
-                client,
-                run_id,
-            )),
+            SourcingStrategy::RetryManifest => Self::ServerRetryManifest(
+                OutOfProcessRetryManifestFetcher::new(entity, work_server_addr, client, run_id),
+            ),
         }
+    }
+
+    fn from_strategies(
+        strategies: impl IntoIterator<Item = SourcingStrategy>,
+        entity: Entity,
+        work_server_addr: SocketAddr,
+        client: Box<dyn ConfiguredClient>,
+        run_id: RunId,
+    ) -> Vec<Self> {
+        strategies
+            .into_iter()
+            .map(|strategy| {
+                Self::from_strategy(
+                    strategy,
+                    entity,
+                    work_server_addr,
+                    client.boxed_clone(),
+                    run_id.clone(),
+                )
+            })
+            .collect()
     }
 }
 
@@ -128,8 +143,7 @@ impl Fetcher {
     async fn fetch_next_tests(&mut self) -> Result<NextWorkBundle, FetchTestsError> {
         // Test fetching works in two phases:
         //
-        //   1. Fetch the schedule of the manifest to be run by the worker from the queue, either
-        //      online (FRESH) or offline (NEW_PROCESS_RETRY).
+        //   1. Fetch the schedule of the manifest to be run by the worker from the queue.
         //      This schedule is used to hydrate the retry manifest tracker as it comes in.
         //   2. After the full manifest has been pulled, defer to the manifest tracker to supply
         //      all tests that should be re-run.
@@ -138,19 +152,25 @@ impl Fetcher {
         //      One the retry manifest issues [NextWork::EndOfWork], there are no more tests to be
         //      run.
         loop {
-            let initial_source = std::mem::take(&mut self.initial_source);
+            let initial_sources = &mut self.initial_sources_rev;
 
-            match initial_source {
+            match initial_sources.last_mut() {
                 Some(source) => {
-                    let tests = match source {
-                        InitialSource::Fresh(mut s) => {
-                            let tests = s.get_next_tests().await;
-                            // Put the source back, we may need it to fetch incremental tests again.
-                            self.initial_source = Some(InitialSource::Fresh(s));
-                            tests
+                    let mut tests = match source {
+                        InitialSource::Queue(s) => {
+                            tracing::debug!("Fetching from fresh manifest");
+                            s.get_next_tests().await
                         }
-                        InitialSource::Retry(s) => s.get_next_tests().await?,
+                        InitialSource::ServerRetryManifest(s) => {
+                            tracing::debug!("Fetching from retry manifest");
+                            s.get_next_tests().await?
+                        }
                     };
+
+                    if tests.eow.0 {
+                        self.initial_sources_rev.pop();
+                    }
+                    tests.eow = Eow(tests.eow.0 && self.initial_sources_rev.is_empty());
 
                     let hydration_status = self
                         .retry_source
@@ -169,8 +189,6 @@ impl Fetcher {
                                 tests.eow.0,
                                 "reached hydration end of manifest status, but not EOW"
                             );
-
-                            self.initial_source = None;
 
                             if tests.work.is_empty() {
                                 // This is a non-empty manifest but there is no work in this batch;
@@ -240,7 +258,7 @@ mod test {
 
         let (server, queue_fetcher) = scaffold_server(1).await;
         let (mut fetcher, _results) = Fetcher::new_help(
-            InitialSource::Fresh(queue_fetcher),
+            vec![InitialSource::Queue(queue_fetcher)],
             INIT_RUN_NUMBER,
             Duration::MAX,
         );
@@ -266,7 +284,7 @@ mod test {
 
         let (server, queue_fetcher) = scaffold_server().await;
         let (mut fetcher, _results) = Fetcher::new_help(
-            InitialSource::Retry(queue_fetcher),
+            vec![InitialSource::ServerRetryManifest(queue_fetcher)],
             INIT_RUN_NUMBER,
             Duration::MAX,
         );
@@ -292,7 +310,7 @@ mod test {
 
         let (server, queue_fetcher) = scaffold_server(1).await;
         let (mut fetcher, _results) = Fetcher::new_help(
-            InitialSource::Fresh(queue_fetcher),
+            vec![InitialSource::Queue(queue_fetcher)],
             INIT_RUN_NUMBER,
             Duration::MAX,
         );
@@ -353,7 +371,7 @@ mod test {
 
         let (server, queue_fetcher) = scaffold_server().await;
         let (mut fetcher, _results) = Fetcher::new_help(
-            InitialSource::Retry(queue_fetcher),
+            vec![InitialSource::ServerRetryManifest(queue_fetcher)],
             INIT_RUN_NUMBER,
             Duration::MAX,
         );
@@ -398,7 +416,7 @@ mod test {
 
         let (server, queue_fetcher) = scaffold_server(1).await;
         let (mut fetcher, _results) = Fetcher::new_help(
-            InitialSource::Fresh(queue_fetcher),
+            vec![InitialSource::Queue(queue_fetcher)],
             INIT_RUN_NUMBER,
             Duration::MAX,
         );
@@ -548,7 +566,7 @@ mod test {
 
             let (server, queue_fetcher) = scaffold_server(1).await;
             let (mut fetcher, mut results_tracker) = Fetcher::new_help(
-                InitialSource::Fresh(queue_fetcher),
+                vec![InitialSource::Queue(queue_fetcher)],
                 INIT_RUN_NUMBER + 2,
                 Duration::MAX,
             );
@@ -563,7 +581,7 @@ mod test {
 
             let (server, queue_fetcher) = scaffold_server().await;
             let (mut fetcher, mut results_tracker) = Fetcher::new_help(
-                InitialSource::Retry(queue_fetcher),
+                vec![InitialSource::ServerRetryManifest(queue_fetcher)],
                 INIT_RUN_NUMBER + 2,
                 Duration::MAX,
             );
@@ -580,7 +598,7 @@ mod test {
 
         let (server, queue_fetcher) = scaffold_server(1).await;
         let (mut fetcher, mut results_tracker) = Fetcher::new_help(
-            InitialSource::Fresh(queue_fetcher),
+            vec![InitialSource::Queue(queue_fetcher)],
             INIT_RUN_NUMBER + 1,
             Duration::MAX,
         );
@@ -646,7 +664,7 @@ mod test {
 
         let (server, queue_fetcher) = scaffold_server().await;
         let (mut fetcher, mut results_tracker) = Fetcher::new_help(
-            InitialSource::Retry(queue_fetcher),
+            vec![InitialSource::ServerRetryManifest(queue_fetcher)],
             INIT_RUN_NUMBER + 1,
             Duration::MAX,
         );
@@ -701,5 +719,79 @@ mod test {
         };
 
         let ((), ()) = tokio::join!(server_task, fetch_task);
+    }
+
+    #[tokio::test]
+    async fn fetch_retry_manifest_then_fetch_from_queue() {
+        use out_of_process_retry_manifest_fetcher::test as rm;
+        use persistent_test_fetcher::test as pf;
+
+        let (retry_server, retry_fetcher) = rm::scaffold_server().await;
+        let (queue_server, queue_fetcher) = pf::scaffold_server(1).await;
+        let (mut fetcher, mut results_tracker) = Fetcher::new_help(
+            vec![
+                InitialSource::ServerRetryManifest(retry_fetcher),
+                InitialSource::Queue(queue_fetcher),
+            ],
+            INIT_RUN_NUMBER + 1,
+            Duration::MAX,
+        );
+
+        let retry_sender_task = async move {
+            for i in 0..2 {
+                let mut conn = rm::server_establish(&*retry_server).await;
+                rm::server_send_bundle(
+                    &mut conn,
+                    [WorkerTest::new(spec(i + 1), INIT_RUN_NUMBER)],
+                    Eow(i == 1),
+                )
+                .await;
+            }
+        };
+
+        let queue_sender_task = async move {
+            let mut conn = pf::server_establish(&*queue_server).await;
+            for i in 0..2 {
+                pf::server_send_bundle(
+                    &mut conn,
+                    [WorkerTest::new(spec(i + 3), INIT_RUN_NUMBER)],
+                    Eow(i == 1),
+                )
+                .await;
+            }
+        };
+
+        let fetch_task = async move {
+            let NextWorkBundle { work, eow } = fetcher.get_next_tests().await.unwrap();
+            assert_eq!(work, [WorkerTest::new(spec(1), INIT_RUN_NUMBER)]);
+            assert!(!eow, "should come back for server retry manifest");
+
+            let NextWorkBundle { work, eow } = fetcher.get_next_tests().await.unwrap();
+            assert_eq!(work, [WorkerTest::new(spec(2), INIT_RUN_NUMBER)]);
+            assert!(!eow, "should come back for online queue");
+
+            let NextWorkBundle { work, eow } = fetcher.get_next_tests().await.unwrap();
+            assert_eq!(work, [WorkerTest::new(spec(3), INIT_RUN_NUMBER)]);
+            assert!(!eow, "should come back for online queue");
+
+            let NextWorkBundle { work, eow } = fetcher.get_next_tests().await.unwrap();
+            assert_eq!(work, [WorkerTest::new(spec(4), INIT_RUN_NUMBER)]);
+            assert!(!eow, "should come back for online queue");
+
+            for i in 0..4 {
+                results_tracker.account_results([&AssociatedTestResultsBuilder::new(
+                    wid(i + 1),
+                    INIT_RUN_NUMBER,
+                    [TestResultBuilder::new(test(i + 1), SUCCESS)],
+                )
+                .build()]);
+            }
+
+            let NextWorkBundle { work, eow } = fetcher.get_next_tests().await.unwrap();
+            assert!(work.is_empty());
+            assert!(eow, "should have nothing to retry");
+        };
+
+        tokio::join!(retry_sender_task, queue_sender_task, fetch_task);
     }
 }


### PR DESCRIPTION
This patch improves ABQ's behavior when an ABQ runner is terminated before
being assigned all applicable test in a run manifest. In previous versions of
ABQ, retrying such a runner would only retry the tests the runner was assigned
before it terminated. Starting with this patch, a runner that connects for a run
ID after it was terminated will run all tests it ran on its first connection,
and then pull tests from the run queue.

ABQ continues to cancel runs when a runner is terminated with SIGTERM, SIGINT,
or SIGQUIT. The changes here apply to runners terminated in other ways, for
example via SIGKILL.

Mechanically, this is done by telling a runner that connects for a retry that it
should always check the online queue after the retry manifest is complete. In the
case where the online queue is empty, this is a no-op.