### PR TITLE
Update default rwx abq api to cloud host

### DIFF
--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Register new release abq api
         run: |
-          curl -X "POST" "https://abq.build/api/releases" \
+          curl -X "POST" "https://cloud.rwx.com/abq/api/releases" \
           --fail-with-body \
           -H 'Authorization: Bearer ${{ secrets.RWX_PRODUCTION_CREATE_RELEASE_ACCESS_TOKEN }}' \
           -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \

--- a/.github/workflows/release_staging.yml
+++ b/.github/workflows/release_staging.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Register a new release with the abq api to a release channel
         if: inputs.release_channel != ''
         run: |
-          curl -X "POST" "https://staging.abq.build/api/releases" \
+          curl -X "POST" "https://staging.cloud.rwx.com/abq/api/releases" \
           --fail-with-body \
           -H 'Authorization: Bearer ${{ secrets.RWX_STAGING_CREATE_RELEASE_ACCESS_TOKEN }}' \
           -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
@@ -34,7 +34,7 @@ jobs:
       - name: Register a new release with the abq api without a release channel
         if: inputs.release_channel == ''
         run: |
-          curl -X "POST" "https://staging.abq.build/api/releases" \
+          curl -X "POST" "https://staging.cloud.rwx.com/abq/api/releases" \
           --fail-with-body \
           -H 'Authorization: Bearer ${{ secrets.RWX_STAGING_CREATE_RELEASE_ACCESS_TOKEN }}' \
           -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "abq"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "abq_dot_reporter",
  "abq_hosted",

--- a/bin/manage_dev_queue
+++ b/bin/manage_dev_queue
@@ -6,7 +6,7 @@ cd $(git rev-parse --show-toplevel)
 
 source bin/dev_queue_state.sh
 
-MANUAL_API='https://staging.abq.build/api/queue/manual'
+MANUAL_API='https://staging.cloud.rwx.com/abq/api/queue/manual'
 AUTH_HEADER="Authorization: Bearer $ABQ_CREATE_MANUAL_ACCESS_TOKEN"
 
 echoerr() { echo "$@" 1>&2; }
@@ -21,7 +21,7 @@ infer_queue_version () {
 }
 
 fetch_state () {
-  curl 'https://staging.abq.build/api/queue/manual' \
+  curl 'https://staging.cloud.rwx.com/abq/api/queue/manual' \
     -X GET \
     -H "Authorization: Bearer $ABQ_CREATE_MANUAL_ACCESS_TOKEN" \
     -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \

--- a/crates/abq_hosted/src/config.rs
+++ b/crates/abq_hosted/src/config.rs
@@ -67,7 +67,7 @@ impl HostedQueueConfig {
     where
         U: AsRef<str>,
     {
-        // e.g. abq.build/api/queue
+        // e.g. cloud.rwx.com/abq/api/queue
         let queue_api = Url::try_from(api_url.as_ref())
             .map_err(|e| Error::InvalidUrl(e.to_string()))
             .and_then(|mut api| {

--- a/crates/abq_hosted/src/lib.rs
+++ b/crates/abq_hosted/src/lib.rs
@@ -3,7 +3,7 @@ mod config;
 mod error;
 mod notify;
 
-pub const DEFAULT_RWX_ABQ_API_URL: &str = "https://abq.build/api";
+pub const DEFAULT_RWX_ABQ_API_URL: &str = "https://cloud.rwx.com/abq/api";
 
 pub use access_token::AccessToken;
 pub use config::AccessTokenKind;

--- a/crates/abq_hosted/src/notify.rs
+++ b/crates/abq_hosted/src/notify.rs
@@ -48,7 +48,7 @@ async fn record_test_run_metadata_help<U>(
 where
     U: AsRef<str>,
 {
-    // e.g. abq.build/api/record_test_run
+    // e.g. cloud.rwx.com/abq/api/record_test_run
     let queue_api = Url::try_from(api_url.as_ref())
         .map_err(|e| Error::InvalidUrl(e.to_string()))
         .and_then(|mut api| {


### PR DESCRIPTION
Updates abq to default to the rwx cloud host instead of the rwx abq host that is being deprecated.

Tested locally via:

```
cd testdata/jest/npm-jest-project-with-failures
NIX_ABQ_VERSION=1.7.1 cargo b --all-features
npm install
RWX_ACCESS_TOKEN=<omitted> ../../../target/debug/abq test --run-id tony-test-run-id -- npm test
```

![image](https://github.com/rwx-research/abq/assets/62091/8297fcef-b868-46e7-acbf-501b7a1b1f77)
