### PR TITLE
Prepare ABQ 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.7.2
+
+ABQ 1.7.2 is a patch release.
+
+This release changes the underlying default abq remote host when interacting with
+the rwx cloud api.
+
 ## 1.7.1
 
 ABQ 1.7.1 is a patch release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "abq"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "abq_dot_reporter",
  "abq_hosted",

--- a/crates/abq_cli/Cargo.toml
+++ b/crates/abq_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abq"
-version = "1.7.1"
+version = "1.7.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
ABQ 1.7.2 is a patch release.

This release changes the underlying default abq host when interacting with rwx cloud api.