### PR TITLE
Adds a --local flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "abq"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "abq_dot_reporter",
  "abq_hosted",

--- a/crates/abq_cli/Cargo.toml
+++ b/crates/abq_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abq"
-version = "1.8.1"
+version = "1.9.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/abq_cli/src/args.rs
+++ b/crates/abq_cli/src/args.rs
@@ -245,6 +245,12 @@ pub enum Command {
             .conflicts_with("tls_key"),
         )
     )]
+    #[command(group(
+        ArgGroup::new("local-queue-addr-exclusion") // don't allow both queue_addr and local params
+            .multiple(false)
+            .args(["local", "queue_addr"]),
+        )
+    )]
     Test {
         /// The number of the test worker connecting for a test suite run.
         ///
@@ -273,6 +279,12 @@ pub enum Command {
         /// Cannot be used with --queue-addr (implies: not using the ABQ API).
         #[clap(long, required = false, env("RWX_ACCESS_TOKEN"))]
         access_token: Option<AccessToken>,
+
+        /// When specified, runs ABQ in local mode only.
+        ///
+        /// Cannot be used with --queue-addr since a local queue will be used.
+        #[clap(long, required = false, env("ABQ_LOCAL"), action)]
+        local: bool,
 
         /// Address of the queue where the test command will be sent.
         ///

--- a/crates/abq_cli/src/workers.rs
+++ b/crates/abq_cli/src/workers.rs
@@ -24,6 +24,7 @@ use signal_hook_tokio::Signals;
 
 use crate::reporting::{build_reporters, ReporterKind, StdoutPreferences};
 use crate::workers::reporting::create_reporting_task;
+use crate::QueueLocation;
 
 use self::reporting::ReportingTaskHandle;
 
@@ -39,6 +40,7 @@ pub struct TestRunMetadata {
     pub access_token: Option<abq_hosted::AccessToken>,
     pub run_id: RunId,
     pub record_telemetry: bool,
+    pub queue_location: QueueLocation,
 }
 
 pub async fn start_workers_standalone(
@@ -188,7 +190,9 @@ async fn do_shutdown(
             .write_short_summary_lines(&mut stdout, ShortSummaryGrouping::Runner)
             .unwrap();
         println!("\n");
-        if execution_mode == ExecutionMode::WriteNormal {
+        if execution_mode == ExecutionMode::WriteNormal
+            && test_run_metadata.queue_location.is_remote()
+        {
             println!("Run the following command to replay these tests locally:");
             println!("\n");
             println!(


### PR DESCRIPTION
This flag forces ABQ to use an ephemeral queue rather than a remote queue, even if a valid access token is configured.