### PR TITLE
Don't worry about an explicit run ID when --local is specified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "abq"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "abq_dot_reporter",
  "abq_hosted",

--- a/crates/abq_cli/Cargo.toml
+++ b/crates/abq_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abq"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2021"
 
 [dependencies]

--- a/crates/abq_cli/src/main.rs
+++ b/crates/abq_cli/src/main.rs
@@ -392,7 +392,7 @@ async fn abq_main() -> anyhow::Result<ExitCode> {
             let stdout_preferences = StdoutPreferences::new(color);
 
             let external_run_id = run_id.or(inferred_run_id);
-            let explicit_run_id_provided = external_run_id.is_some();
+            let explicit_run_id_provided = external_run_id.is_some() && !local;
             let run_id = external_run_id.unwrap_or_else(RunId::unique);
 
             let working_dir =


### PR DESCRIPTION
Right now if you provide a run ID and specify --local, you'll get an error asking if you meant to use an ephemeral queue or not. Since you specified --local we can be confident that you did mean to use an ephemeral queue.